### PR TITLE
Add Fantasy Premier League deadline notifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and fill in your Pushover credentials.
+PUSHOVER_TOKEN=your_application_token
+PUSHOVER_USER_KEY=your_user_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-# FPL
+# FPL Deadline Notifier
+
+This project provides a small command-line application that reminds you of
+upcoming Fantasy Premier League (FPL) deadlines. It polls the public FPL API,
+calculates the next gameweek deadline, and sends a push notification via
+[Pushover](https://pushover.net/) two hours before the deadline by default.
+
+## Features
+
+- Fetches official FPL gameweek deadlines from the public API.
+- Schedules a single notification per gameweek with a configurable lead time.
+- Uses [Pushover](https://pushover.net/) for cross-platform push notifications.
+- Supports custom notification sounds, device targeting, and message timezone.
+- Includes a test mode to send the next upcoming deadline notification on-demand.
+
+## Requirements
+
+- Python 3.11 or newer
+- A Pushover account, application token, and user key
+- API access to the public FPL endpoints (no authentication required)
+- Optional: [`tzdata`](https://pypi.org/project/tzdata/) if your operating system
+  does not ship IANA timezone information (common on Windows servers)
+
+## Installation
+
+Create and activate a virtual environment (optional but recommended):
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+The application does not require any third-party Python packages. If you want to
+run the unit tests you will need [pytest](https://pytest.org/) available in your
+environment.
+
+Copy the example environment file and populate it with your Pushover credentials:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set the following values:
+
+- `PUSHOVER_TOKEN`: The API token for your Pushover application.
+- `PUSHOVER_USER_KEY`: Your personal Pushover user key.
+
+## Usage
+
+Once configured, run the notifier:
+
+```bash
+python -m fpl_notifier
+```
+
+The command keeps running and periodically checks the FPL API. It sleeps until
+the next notification window is within range (two hours by default), sends a
+single push notification, and then waits for the next gameweek.
+
+### Command-line options
+
+```
+python -m fpl_notifier [--lead-hours 2] [--poll-minutes 30] [--timezone Europe/London]
+                        [--sound magic] [--device iphone] [--priority 1] [--verbose]
+                        [--send-test]
+```
+
+- `--lead-hours`: Number of hours before the deadline to send the notification.
+- `--poll-minutes`: How frequently to refresh deadlines while waiting.
+- `--timezone`: Timezone used when displaying the deadline in the notification.
+- `--sound`: Optional Pushover sound name.
+- `--device`: Target a specific registered device.
+- `--priority`: Override the Pushover priority level.
+- `--verbose`: Enable debug logging.
+- `--send-test`: Send the next upcoming deadline notification immediately and exit.
+
+### Example
+
+Send a reminder four hours before each deadline, poll every 15 minutes, and show
+the time in the UK timezone:
+
+```bash
+python -m fpl_notifier --lead-hours 4 --poll-minutes 15 --timezone Europe/London
+```
+
+### Running tests
+
+```bash
+pytest
+```
+
+## Extending
+
+The code is structured around three main modules:
+
+- `fpl_notifier.deadlines`: Fetches and parses deadlines from the FPL API.
+- `fpl_notifier.notifier`: Contains the Pushover integration.
+- `fpl_notifier.service`: Orchestrates polling and scheduling.
+
+You can implement alternative notification channels by creating a class with a
+`send(gameweek, lead_time)` method and passing it to
+`DeadlineNotificationService`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fpl-notifier"
+version = "0.1.0"
+description = "Send push notifications before Fantasy Premier League deadlines"
+readme = "README.md"
+authors = [{name = "FPL Tools"}]
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+fpl-notifier = "fpl_notifier.__main__:main"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["src"]

--- a/src/fpl_notifier/__init__.py
+++ b/src/fpl_notifier/__init__.py
@@ -1,0 +1,13 @@
+"""FPL deadline notification service."""
+
+from .deadlines import GameweekDeadline, fetch_gameweek_deadlines, get_next_gameweek_deadline
+from .notifier import PushoverNotifier
+from .service import DeadlineNotificationService
+
+__all__ = [
+    "GameweekDeadline",
+    "fetch_gameweek_deadlines",
+    "get_next_gameweek_deadline",
+    "PushoverNotifier",
+    "DeadlineNotificationService",
+]

--- a/src/fpl_notifier/__main__.py
+++ b/src/fpl_notifier/__main__.py
@@ -1,0 +1,122 @@
+"""Command-line entry point for the FPL deadline notifier."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from datetime import timedelta
+from typing import Optional
+
+from zoneinfo import ZoneInfo
+
+from .notifier import PushoverNotifier
+from .service import DeadlineNotificationService
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Send push notifications before FPL deadlines")
+    parser.add_argument("--lead-hours", type=float, default=2.0, help="How many hours before the deadline to notify")
+    parser.add_argument(
+        "--poll-minutes",
+        type=float,
+        default=30.0,
+        help="How frequently to refresh the FPL API while waiting for the next deadline",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="UTC",
+        help="Timezone name (IANA) used when displaying the deadline time in the notification",
+    )
+    parser.add_argument(
+        "--sound",
+        default=None,
+        help="Optional Pushover notification sound",
+    )
+    parser.add_argument("--device", default=None, help="Optional Pushover device name")
+    parser.add_argument(
+        "--priority",
+        type=int,
+        default=None,
+        help="Optional Pushover priority override",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--send-test",
+        action="store_true",
+        help="Send a test notification immediately and exit",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_env_file(path: str = ".env") -> None:
+    if not os.path.exists(path):
+        return
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
+                striped = line.strip()
+                if not striped or striped.startswith("#"):
+                    continue
+                if "=" not in striped:
+                    continue
+                key, value = striped.split("=", 1)
+                os.environ.setdefault(key.strip(), value.strip())
+    except OSError:
+        pass
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    _load_env_file()
+
+    args = _parse_args(argv)
+    _configure_logging(args.verbose)
+
+    token = os.environ.get("PUSHOVER_TOKEN")
+    user_key = os.environ.get("PUSHOVER_USER_KEY")
+    if not token or not user_key:
+        raise SystemExit(
+            "PUSHOVER_TOKEN and PUSHOVER_USER_KEY environment variables are required for Pushover"
+        )
+
+    try:
+        tz = ZoneInfo(args.timezone)
+    except Exception as exc:  # pragma: no cover - user configuration issue
+        raise SystemExit(f"Invalid timezone '{args.timezone}': {exc}")
+
+    notifier = PushoverNotifier(
+        token=token,
+        user_key=user_key,
+        timezone=tz,
+        sound=args.sound,
+        device=args.device,
+        priority=args.priority,
+    )
+
+    lead_time = timedelta(hours=args.lead_hours)
+    poll_interval = timedelta(minutes=args.poll_minutes)
+    service = DeadlineNotificationService(
+        notifier,
+        lead_time=lead_time,
+        poll_interval=poll_interval,
+    )
+
+    if args.send_test:
+        from .deadlines import get_next_gameweek_deadline
+
+        upcoming = get_next_gameweek_deadline()
+        if not upcoming:
+            raise SystemExit("No upcoming deadlines found")
+        notifier.send(upcoming, lead_time)
+        return
+
+    service.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/src/fpl_notifier/deadlines.py
+++ b/src/fpl_notifier/deadlines.py
@@ -1,0 +1,109 @@
+"""Utilities for working with Fantasy Premier League deadlines."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+from typing import Callable, List, Optional, Sequence
+from urllib import request
+
+LOGGER = logging.getLogger(__name__)
+
+API_URL = "https://fantasy.premierleague.com/api/bootstrap-static/"
+
+FetchJson = Callable[[str, int], dict]
+
+
+@dataclass(frozen=True)
+class GameweekDeadline:
+    """Represents a Fantasy Premier League gameweek deadline."""
+
+    event_id: int
+    name: str
+    deadline: datetime
+
+    def __post_init__(self) -> None:
+        if self.deadline.tzinfo is None:
+            raise ValueError("deadline must be timezone aware")
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"{self.name} (GW {self.event_id}) @ {self.deadline.isoformat()}"
+
+
+def _coerce_to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def parse_deadline(deadline_str: str) -> datetime:
+    """Parse a deadline string from the FPL API into an aware UTC datetime."""
+
+    # FPL returns strings such as "2024-08-16T18:30:00Z".
+    if deadline_str.endswith("Z"):
+        deadline_str = deadline_str[:-1] + "+00:00"
+    dt = datetime.fromisoformat(deadline_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
+def _default_fetch(url: str, timeout: int) -> dict:
+    with request.urlopen(url, timeout=timeout) as response:
+        return json.load(response)
+
+
+def fetch_gameweek_deadlines(
+    *,
+    now: Optional[datetime] = None,
+    fetch_json: Optional[FetchJson] = None,
+) -> List[GameweekDeadline]:
+    """Fetch upcoming gameweek deadlines from the public FPL API."""
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    else:
+        now = _coerce_to_utc(now)
+
+    fetcher = fetch_json or _default_fetch
+    LOGGER.debug("Fetching FPL data from %s", API_URL)
+    payload = fetcher(API_URL, 10)
+    events: Sequence[dict] = payload.get("events", [])
+    deadlines: List[GameweekDeadline] = []
+    for event in events:
+        try:
+            deadline = parse_deadline(event["deadline_time"])
+        except (KeyError, TypeError, ValueError) as exc:
+            LOGGER.warning("Skipping event with invalid deadline: %s", exc)
+            continue
+        if deadline <= now:
+            # Skip past deadlines, including the current active gameweek.
+            continue
+        deadlines.append(
+            GameweekDeadline(
+                event_id=int(event["id"]),
+                name=str(event.get("name") or event.get("event", "Gameweek")),
+                deadline=deadline,
+            )
+        )
+
+    deadlines.sort(key=lambda gw: gw.deadline)
+    LOGGER.debug("Found %d upcoming deadlines", len(deadlines))
+    return deadlines
+
+
+def get_next_gameweek_deadline(
+    *,
+    now: Optional[datetime] = None,
+    fetch_json: Optional[FetchJson] = None,
+) -> Optional[GameweekDeadline]:
+    """Return the next upcoming gameweek deadline, if one exists."""
+
+    deadlines = fetch_gameweek_deadlines(now=now, fetch_json=fetch_json)
+    if not deadlines:
+        return None
+    return deadlines[0]

--- a/src/fpl_notifier/notifier.py
+++ b/src/fpl_notifier/notifier.py
@@ -1,0 +1,104 @@
+"""Notification backends for delivering deadline reminders."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Optional
+from urllib import error, parse, request
+
+from zoneinfo import ZoneInfo
+
+from .deadlines import GameweekDeadline
+
+LOGGER = logging.getLogger(__name__)
+
+PUSHOVER_API_URL = "https://api.pushover.net/1/messages.json"
+
+
+def _format_timedelta(delta: timedelta) -> str:
+    total_seconds = int(delta.total_seconds())
+    if total_seconds < 60:
+        return f"{total_seconds} seconds"
+    minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    parts = []
+    if hours:
+        parts.append(f"{hours} hour{'s' if hours != 1 else ''}")
+    if minutes:
+        parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+    if seconds and not hours:
+        parts.append(f"{seconds} second{'s' if seconds != 1 else ''}")
+    return " and ".join(parts)
+
+
+class PushoverNotifier:
+    """Send push notifications using the Pushover service."""
+
+    def __init__(
+        self,
+        token: str,
+        user_key: str,
+        *,
+        opener: Optional[request.OpenerDirector] = None,
+        timezone: Optional[ZoneInfo] = None,
+        sound: Optional[str] = None,
+        device: Optional[str] = None,
+        priority: Optional[int] = None,
+        timeout: int = 10,
+    ) -> None:
+        if not token:
+            raise ValueError("token is required")
+        if not user_key:
+            raise ValueError("user_key is required")
+
+        self.token = token
+        self.user_key = user_key
+        self.opener = opener or request.build_opener()
+        self.timezone = timezone or ZoneInfo("UTC")
+        self.sound = sound
+        self.device = device
+        self.priority = priority
+        self.timeout = timeout
+
+    def _build_payload(self, gameweek: GameweekDeadline, lead_time: timedelta) -> dict:
+        deadline_local = gameweek.deadline.astimezone(self.timezone)
+        formatted_lead = _format_timedelta(lead_time)
+        title = f"FPL deadline in {formatted_lead}"
+        message = (
+            f"{gameweek.name} (GW {gameweek.event_id}) deadline at "
+            f"{deadline_local.strftime('%Y-%m-%d %H:%M %Z')}"
+        )
+        payload = {
+            "token": self.token,
+            "user": self.user_key,
+            "title": title,
+            "message": message,
+        }
+        if self.sound:
+            payload["sound"] = self.sound
+        if self.device:
+            payload["device"] = self.device
+        if self.priority is not None:
+            payload["priority"] = str(self.priority)
+        return payload
+
+    def send(self, gameweek: GameweekDeadline, lead_time: timedelta) -> None:
+        """Send a push notification for the provided gameweek."""
+
+        payload = self._build_payload(gameweek, lead_time)
+        LOGGER.info("Sending push notification for %s", gameweek)
+        encoded = parse.urlencode(payload).encode()
+        req = request.Request(PUSHOVER_API_URL, data=encoded)
+        try:
+            with self.opener.open(req, timeout=self.timeout) as response:
+                status = response.getcode()
+                body = response.read().decode("utf-8", errors="replace")
+        except error.HTTPError as exc:
+            LOGGER.error("Pushover rejected the request: %s", exc.read().decode("utf-8", errors="replace"))
+            raise
+        except error.URLError as exc:
+            LOGGER.error("Failed to contact Pushover: %s", exc)
+            raise
+        else:
+            LOGGER.debug("Notification accepted (status %s): %s", status, body)

--- a/src/fpl_notifier/service.py
+++ b/src/fpl_notifier/service.py
@@ -1,0 +1,118 @@
+"""High level orchestration for scheduling deadline notifications."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+import time
+from typing import Callable, Dict, Optional
+
+from .deadlines import GameweekDeadline, fetch_gameweek_deadlines
+
+LOGGER = logging.getLogger(__name__)
+
+SleepFunction = Callable[[float], None]
+Fetcher = Callable[..., list[GameweekDeadline]]
+
+
+class DeadlineNotificationService:
+    """Continuously polls the FPL API and delivers notifications."""
+
+    def __init__(
+        self,
+        notifier,
+        *,
+        lead_time: timedelta = timedelta(hours=2),
+        poll_interval: timedelta = timedelta(hours=6),
+        fetcher: Fetcher = fetch_gameweek_deadlines,
+        sleep_func: SleepFunction = time.sleep,
+    ) -> None:
+        if lead_time <= timedelta(0):
+            raise ValueError("lead_time must be positive")
+        if poll_interval <= timedelta(0):
+            raise ValueError("poll_interval must be positive")
+
+        self.notifier = notifier
+        self.lead_time = lead_time
+        self.poll_interval = poll_interval
+        self.fetcher = fetcher
+        self.sleep = sleep_func
+        self._sent: Dict[int, datetime] = {}
+
+    def _prune_sent(self, now: datetime) -> None:
+        for event_id, deadline in list(self._sent.items()):
+            expiry = deadline + self.poll_interval
+            if now >= expiry:
+                LOGGER.debug("Removing expired notification cache for GW %s", event_id)
+                del self._sent[event_id]
+
+    def _get_now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def step(self, *, now: Optional[datetime] = None) -> float:
+        """Perform a single scheduling step and return the suggested sleep time."""
+
+        raw_now = now or self._get_now()
+        if raw_now.tzinfo is None:
+            now = raw_now.replace(tzinfo=timezone.utc)
+        else:
+            now = raw_now.astimezone(timezone.utc)
+        LOGGER.debug("Scheduler step at %s", now.isoformat())
+        self._prune_sent(now)
+
+        try:
+            deadlines = self.fetcher(now=now)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.error("Failed to fetch deadlines: %s", exc, exc_info=True)
+            return self.poll_interval.total_seconds()
+
+        if not deadlines:
+            LOGGER.info("No upcoming deadlines. Sleeping for %s", self.poll_interval)
+            return self.poll_interval.total_seconds()
+
+        upcoming = deadlines[0]
+        if upcoming.event_id in self._sent:
+            LOGGER.debug(
+                "Already notified about %s. Sleeping for %s", upcoming, self.poll_interval
+            )
+            return self.poll_interval.total_seconds()
+
+        notify_at = upcoming.deadline - self.lead_time
+        if notify_at <= now:
+            LOGGER.info("Within lead time for %s. Sending notification immediately.", upcoming)
+            self._deliver(upcoming)
+            return self.poll_interval.total_seconds()
+
+        wait_seconds = (notify_at - now).total_seconds()
+        if wait_seconds > self.poll_interval.total_seconds():
+            LOGGER.debug(
+                "Notification is %.2f hours away; refreshing after %s",
+                wait_seconds / 3600.0,
+                self.poll_interval,
+            )
+            return self.poll_interval.total_seconds()
+
+        LOGGER.info(
+            "Scheduling notification for %s in %.1f minutes",
+            upcoming,
+            wait_seconds / 60.0,
+        )
+        return max(wait_seconds, 0.0)
+
+    def _deliver(self, gameweek: GameweekDeadline) -> None:
+        try:
+            self.notifier.send(gameweek, self.lead_time)
+            self._sent[gameweek.event_id] = gameweek.deadline
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.error("Failed to send notification: %s", exc, exc_info=True)
+
+    def run(self) -> None:
+        LOGGER.info("Starting deadline notification service")
+        try:
+            while True:
+                sleep_for = self.step()
+                if sleep_for > 0:
+                    LOGGER.debug("Sleeping for %.2f seconds", sleep_for)
+                    self.sleep(sleep_for)
+        except KeyboardInterrupt:  # pragma: no cover - manual interrupt
+            LOGGER.info("Shutting down notification service")

--- a/tests/test_deadlines.py
+++ b/tests/test_deadlines.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timezone
+
+from fpl_notifier.deadlines import GameweekDeadline, fetch_gameweek_deadlines, get_next_gameweek_deadline, parse_deadline
+
+
+class DummyFetcher:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = 0
+
+    def __call__(self, url, timeout):
+        self.calls += 1
+        return self.payload
+
+
+def test_parse_deadline_handles_z_suffix():
+    parsed = parse_deadline("2024-08-16T18:30:00Z")
+    assert parsed.tzinfo is not None
+    assert parsed == datetime(2024, 8, 16, 18, 30, tzinfo=timezone.utc)
+
+
+def test_fetch_gameweek_deadlines_filters_past_events():
+    payload = {
+        "events": [
+            {
+                "id": 1,
+                "name": "Gameweek 1",
+                "deadline_time": "2024-08-10T10:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "Gameweek 2",
+                "deadline_time": "2024-08-20T10:00:00Z",
+            },
+        ]
+    }
+    fetcher = DummyFetcher(payload)
+    now = datetime(2024, 8, 15, tzinfo=timezone.utc)
+
+    deadlines = fetch_gameweek_deadlines(fetch_json=fetcher, now=now)
+    assert [d.event_id for d in deadlines] == [2]
+    assert fetcher.calls == 1
+
+
+def test_get_next_gameweek_deadline_returns_none_when_empty():
+    payload = {"events": []}
+    fetcher = DummyFetcher(payload)
+
+    assert get_next_gameweek_deadline(fetch_json=fetcher) is None
+
+
+def test_get_next_gameweek_deadline_returns_first_upcoming():
+    payload = {
+        "events": [
+            {
+                "id": 1,
+                "name": "Gameweek 1",
+                "deadline_time": "2024-08-10T10:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "Gameweek 2",
+                "deadline_time": "2024-09-01T09:00:00Z",
+            },
+        ]
+    }
+    fetcher = DummyFetcher(payload)
+    now = datetime(2024, 8, 1, tzinfo=timezone.utc)
+
+    next_deadline = get_next_gameweek_deadline(fetch_json=fetcher, now=now)
+    assert isinstance(next_deadline, GameweekDeadline)
+    assert next_deadline.event_id == 1

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+
+from fpl_notifier.deadlines import GameweekDeadline
+from fpl_notifier.notifier import PushoverNotifier, _format_timedelta
+
+
+def test_format_timedelta_human_readable():
+    assert _format_timedelta(timedelta(seconds=45)) == "45 seconds"
+    assert _format_timedelta(timedelta(minutes=1, seconds=30)) == "1 minute and 30 seconds"
+    assert _format_timedelta(timedelta(hours=2, minutes=15)) == "2 hours and 15 minutes"
+
+
+class DummyResponse:
+    def __init__(self):
+        self.data = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return b"{\"status\":1}"
+
+    def getcode(self):
+        return 200
+
+
+class DummyOpener:
+    def __init__(self):
+        self.last_request = None
+        self.response = DummyResponse()
+
+    def open(self, request_obj, timeout=0):
+        self.last_request = request_obj
+        return self.response
+
+
+def test_pushover_notifier_builds_payload_and_posts():
+    opener = DummyOpener()
+
+    notifier = PushoverNotifier("token", "user", opener=opener)
+    gameweek = GameweekDeadline(
+        event_id=5,
+        name="Gameweek 5",
+        deadline=datetime(2024, 9, 12, 16, 30, tzinfo=timezone.utc),
+    )
+    notifier.send(gameweek, timedelta(hours=2))
+
+    assert opener.last_request is not None
+    assert opener.last_request.full_url == "https://api.pushover.net/1/messages.json"
+    sent_payload = opener.last_request.data.decode()
+    assert "token=token" in sent_payload
+    assert "user=user" in sent_payload
+    assert "Gameweek+5" in sent_payload
+    assert "FPL+deadline+in+2+hours" in sent_payload

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from fpl_notifier.deadlines import GameweekDeadline
+from fpl_notifier.service import DeadlineNotificationService
+
+
+class FakeNotifier:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, gameweek, lead_time):
+        self.sent.append((gameweek, lead_time))
+
+
+def make_deadline(event_id: int, days_ahead: float) -> GameweekDeadline:
+    deadline = datetime(2024, 8, 1, tzinfo=timezone.utc) + timedelta(days=days_ahead)
+    return GameweekDeadline(event_id=event_id, name=f"GW{event_id}", deadline=deadline)
+
+
+def test_step_waits_until_within_poll_interval():
+    notifier = FakeNotifier()
+    now = datetime(2024, 7, 1, tzinfo=timezone.utc)
+    deadlines = [make_deadline(1, 10)]
+
+    def fetcher(now=None):
+        return deadlines
+
+    service = DeadlineNotificationService(
+        notifier,
+        lead_time=timedelta(hours=2),
+        poll_interval=timedelta(hours=6),
+        fetcher=fetcher,
+    )
+
+    sleep = service.step(now=now)
+    assert sleep == pytest.approx(timedelta(hours=6).total_seconds())
+    assert notifier.sent == []
+
+
+def test_step_returns_wait_time_when_notification_is_close():
+    notifier = FakeNotifier()
+    now = datetime(2024, 7, 1, 12, 0, tzinfo=timezone.utc)
+    deadline = datetime(2024, 7, 1, 15, 0, tzinfo=timezone.utc)
+    deadlines = [GameweekDeadline(event_id=2, name="GW2", deadline=deadline)]
+
+    def fetcher(now=None):
+        return deadlines
+
+    service = DeadlineNotificationService(
+        notifier,
+        lead_time=timedelta(hours=2),
+        poll_interval=timedelta(hours=6),
+        fetcher=fetcher,
+    )
+
+    sleep = service.step(now=now)
+    assert sleep == pytest.approx(3600)  # notify at 13:00 UTC
+    assert notifier.sent == []
+
+
+def test_step_sends_notification_when_within_lead_time():
+    notifier = FakeNotifier()
+    now = datetime(2024, 7, 1, 14, 30, tzinfo=timezone.utc)
+    deadline = datetime(2024, 7, 1, 16, 0, tzinfo=timezone.utc)
+    deadlines = [GameweekDeadline(event_id=3, name="GW3", deadline=deadline)]
+
+    def fetcher(now=None):
+        return deadlines
+
+    service = DeadlineNotificationService(
+        notifier,
+        lead_time=timedelta(hours=2),
+        poll_interval=timedelta(hours=6),
+        fetcher=fetcher,
+    )
+
+    sleep = service.step(now=now)
+    assert sleep == pytest.approx(timedelta(hours=6).total_seconds())
+    assert len(notifier.sent) == 1
+    gw, lead = notifier.sent[0]
+    assert gw.event_id == 3
+    assert lead == timedelta(hours=2)
+
+
+def test_step_does_not_send_duplicate_notifications():
+    notifier = FakeNotifier()
+    deadline = datetime(2024, 7, 1, 16, 0, tzinfo=timezone.utc)
+    deadlines = [GameweekDeadline(event_id=4, name="GW4", deadline=deadline)]
+
+    def fetcher(now=None):
+        return deadlines
+
+    service = DeadlineNotificationService(
+        notifier,
+        lead_time=timedelta(hours=2),
+        poll_interval=timedelta(hours=6),
+        fetcher=fetcher,
+    )
+
+    first_sleep = service.step(now=datetime(2024, 7, 1, 14, 30, tzinfo=timezone.utc))
+    assert len(notifier.sent) == 1
+
+    second_sleep = service.step(now=datetime(2024, 7, 1, 15, 0, tzinfo=timezone.utc))
+    assert len(notifier.sent) == 1
+    assert first_sleep == pytest.approx(timedelta(hours=6).total_seconds())
+    assert second_sleep == pytest.approx(timedelta(hours=6).total_seconds())
+
+
+def test_sent_cache_is_cleared_after_deadline():
+    notifier = FakeNotifier()
+    deadline = datetime(2024, 7, 1, 16, 0, tzinfo=timezone.utc)
+    deadlines = [GameweekDeadline(event_id=5, name="GW5", deadline=deadline)]
+
+    def fetcher(now=None):
+        return deadlines
+
+    service = DeadlineNotificationService(
+        notifier,
+        lead_time=timedelta(hours=2),
+        poll_interval=timedelta(hours=6),
+        fetcher=fetcher,
+    )
+
+    service.step(now=datetime(2024, 7, 1, 15, 30, tzinfo=timezone.utc))
+    assert len(notifier.sent) == 1
+
+    # After the deadline passes the cache is cleared and we could notify again
+    next_sleep = service.step(now=datetime(2024, 7, 1, 17, 0, tzinfo=timezone.utc))
+    assert next_sleep == pytest.approx(timedelta(hours=6).total_seconds())
+    assert len(notifier.sent) == 1  # no new send until fetcher provides future deadline


### PR DESCRIPTION
## Summary
- add a command-line app that fetches Fantasy Premier League deadlines and notifies via Pushover
- document configuration, add packaging metadata, and provide an example environment file
- cover deadline parsing, notifier payloads, and scheduling logic with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc767aeb0083328b77e13bcf9d5dc0