### PR TITLE
Add Android app for configurable FPL deadline notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,20 @@ The code is structured around three main modules:
 You can implement alternative notification channels by creating a class with a
 `send(gameweek, lead_time)` method and passing it to
 `DeadlineNotificationService`.
+
+## Android companion app
+
+The repository also includes a Kotlin-based Android application under
+[`android-app/`](android-app/README.md). The app mirrors the CLI flags for lead
+time, polling interval, and timezone configuration, stores preferences via Jetpack
+DataStore, and schedules background reminders using WorkManager. Reminders are
+delivered as native notifications that match the payload produced by the Python
+notifier.
+
+To enable reminders on Android:
+
+1. Open the app and adjust the lead time, poll interval, or timezone as needed.
+2. Toggle **Enable reminders**. Android 13+ will prompt for the notification
+   permission.
+3. Keep the app installed; WorkManager will continue polling the public FPL API
+   and trigger reminders at the configured lead time.

--- a/android-app/.gitignore
+++ b/android-app/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/build/
+/local.properties
+/captures/
+app/build/

--- a/android-app/README.md
+++ b/android-app/README.md
@@ -1,0 +1,26 @@
+# FPL Notifier Android app
+
+This module provides a native Android companion to the Python-based Fantasy Premier League notifier. The application mirrors the command line configuration flags and delivers reminders using the Android notification system.
+
+## Features
+
+* Configure the notification lead time (hours before the deadline), the polling interval (minutes between API refreshes) and the timezone used to display deadlines.
+* Persist configuration through Jetpack DataStore so settings survive application restarts.
+* Background worker built on WorkManager that mirrors the scheduling logic from the Python `DeadlineNotificationService`.
+* Native notifications built with `NotificationCompat` that reuse the existing message format.
+* Automatic pruning of previously sent reminders to avoid duplicate alerts.
+
+## Enabling reminders
+
+1. Launch the application and adjust the lead time, polling interval or timezone as required. Changes are saved automatically.
+2. Toggle **Enable reminders**. On Android 13+ you will be prompted to allow the *POST_NOTIFICATIONS* permission.
+3. Once enabled, the app immediately queues the background worker. The status banner at the bottom of the screen reflects whether reminders are active and shows the last notification that was sent.
+4. To stop reminders, disable the toggle. This cancels the scheduled worker and clears any pending reminders.
+
+## Testing
+
+Run unit tests from the module root:
+
+```bash
+./gradlew test
+```

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,0 +1,61 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.fplnotifier"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.fplnotifier"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    buildFeatures {
+        viewBinding = true
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
+    implementation("androidx.activity:activity-ktx:1.9.2")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+}

--- a/android-app/app/proguard-rules.pro
+++ b/android-app/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.fplnotifier">
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name=".FplNotifierApplication"
+        android:allowBackup="true"
+        android:icon="@android:drawable/ic_dialog_info"
+        android:label="@string/app_name"
+        android:roundIcon="@android:drawable/ic_dialog_info"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.FplNotifier">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android-app/app/src/main/java/com/example/fplnotifier/DeadlineScheduler.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/DeadlineScheduler.kt
@@ -1,0 +1,28 @@
+package com.example.fplnotifier
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+object DeadlineScheduler {
+    private const val UNIQUE_WORK_NAME = "fpl_deadline_worker"
+
+    fun schedule(context: Context, delay: Duration) {
+        val safeDelay = if (delay.isNegative) Duration.ZERO else delay
+        val request = OneTimeWorkRequestBuilder<DeadlineWorker>()
+            .setInitialDelay(safeDelay.toMillis(), TimeUnit.MILLISECONDS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            UNIQUE_WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            request
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/DeadlineWorker.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/DeadlineWorker.kt
@@ -1,0 +1,71 @@
+package com.example.fplnotifier
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.math.roundToLong
+import kotlinx.coroutines.flow.first
+
+class DeadlineWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+
+    private val settingsRepository = SettingsRepository(appContext)
+    private val reminderRepository = ReminderRepository(appContext)
+    private val apiRepository = FplApiRepository()
+
+    override suspend fun doWork(): Result {
+        val settings = settingsRepository.settings.first()
+        if (!settings.notificationsEnabled) {
+            reminderRepository.clearLastNotification()
+            DeadlineScheduler.cancel(applicationContext)
+            return Result.success()
+        }
+
+        val now = Instant.now()
+        val pollDuration = Duration.ofMinutes(settings.pollMinutes)
+        val leadDuration = Duration.ofMillis((settings.leadHours * 3600_000).roundToLong())
+        val zoneId = runCatching { ZoneId.of(settings.timezoneId) }.getOrDefault(ZoneId.systemDefault())
+
+        val sent = reminderRepository.getSentReminders()
+        var cache = reminderRepository.prune(sent, now, pollDuration)
+
+        val deadlines = try {
+            apiRepository.getUpcomingDeadlines(now)
+        } catch (ex: Exception) {
+            reminderRepository.saveSentReminders(cache)
+            DeadlineScheduler.schedule(applicationContext, pollDuration)
+            return Result.success()
+        }
+
+        val upcoming = deadlines.firstOrNull()
+        var nextDelay = pollDuration
+
+        if (upcoming == null) {
+            reminderRepository.saveSentReminders(cache)
+        } else {
+            val alreadySent = cache.any { it.eventId == upcoming.eventId }
+            val notifyAt = upcoming.deadline.minus(leadDuration)
+            if (!notifyAt.isAfter(now)) {
+                if (!alreadySent) {
+                    NotificationHelper.sendNotification(applicationContext, upcoming, leadDuration, zoneId)
+                    cache = cache + ReminderRepository.SentReminder(upcoming.eventId, upcoming.deadline)
+                    reminderRepository.recordNotification(upcoming, zoneId)
+                }
+                nextDelay = pollDuration
+                reminderRepository.saveSentReminders(cache)
+            } else {
+                val waitSeconds = Duration.between(now, notifyAt)
+                nextDelay = if (waitSeconds > pollDuration) pollDuration else waitSeconds
+                reminderRepository.saveSentReminders(cache)
+            }
+        }
+
+        DeadlineScheduler.schedule(applicationContext, nextDelay)
+        return Result.success()
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/FplApiRepository.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/FplApiRepository.kt
@@ -1,0 +1,76 @@
+package com.example.fplnotifier
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.time.Instant
+import java.time.OffsetDateTime
+
+private const val API_URL = "https://fantasy.premierleague.com/api/bootstrap-static/"
+
+typealias JsonFetcher = suspend (String) -> String
+
+class FplApiRepository(
+    private val fetcher: JsonFetcher = { url -> defaultFetch(url) }
+) {
+    suspend fun getUpcomingDeadlines(now: Instant = Instant.now()): List<GameweekDeadline> {
+        val payload = fetcher(API_URL)
+        val root = JSONObject(payload)
+        val events = root.optJSONArray("events") ?: JSONArray()
+        val upcoming = mutableListOf<GameweekDeadline>()
+        for (i in 0 until events.length()) {
+            val event = events.optJSONObject(i) ?: continue
+            val deadlineStr = event.optString("deadline_time", null) ?: continue
+            val deadline = try {
+                parseDeadline(deadlineStr)
+            } catch (ex: Exception) {
+                continue
+            }
+            if (!deadline.isAfter(now)) {
+                continue
+            }
+            val id = event.optInt("id", -1)
+            if (id <= 0) continue
+            val name = event.optString("name", event.optString("event", "Gameweek"))
+            upcoming += GameweekDeadline(
+                eventId = id,
+                name = name,
+                deadline = deadline,
+            )
+        }
+        return upcoming.sortedBy { it.deadline }
+    }
+}
+
+internal fun parseDeadline(raw: String): Instant {
+    return try {
+        OffsetDateTime.parse(raw).toInstant()
+    } catch (ex: Exception) {
+        val normalized = if (raw.endsWith("Z", ignoreCase = true)) {
+            raw.dropLast(1) + "+00:00"
+        } else {
+            raw
+        }
+        OffsetDateTime.parse(normalized).toInstant()
+    }
+}
+
+private suspend fun defaultFetch(url: String): String = withContext(Dispatchers.IO) {
+    val connection = URL(url).openConnection() as HttpURLConnection
+    connection.requestMethod = "GET"
+    connection.connectTimeout = 10_000
+    connection.readTimeout = 10_000
+    try {
+        val stream = connection.inputStream
+        BufferedReader(InputStreamReader(stream)).use { reader ->
+            reader.readText()
+        }
+    } finally {
+        connection.disconnect()
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/FplNotifierApplication.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/FplNotifierApplication.kt
@@ -1,0 +1,10 @@
+package com.example.fplnotifier
+
+import android.app.Application
+
+class FplNotifierApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        NotificationHelper.ensureChannel(this)
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/MainActivity.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/MainActivity.kt
@@ -1,0 +1,158 @@
+package com.example.fplnotifier
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.widget.ArrayAdapter
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.example.fplnotifier.databinding.ActivityMainBinding
+import java.time.ZoneId
+import kotlinx.coroutines.launch
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+    private val zoneIds: List<String> by lazy { ZoneId.getAvailableZoneIds().sorted() }
+    private var suppressToggleListener = false
+
+    private val viewModel: MainViewModel by viewModels {
+        MainViewModelFactory(
+            application,
+            SettingsRepository(applicationContext),
+            ReminderRepository(applicationContext),
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, zoneIds)
+        binding.inputTimezone.setAdapter(adapter)
+
+        observeViewModel()
+        setupListeners()
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collect { state ->
+                    if (binding.inputLeadHours.text?.toString() != state.leadHours) {
+                        binding.inputLeadHours.setText(state.leadHours)
+                    }
+                    if (binding.inputPollMinutes.text?.toString() != state.pollMinutes) {
+                        binding.inputPollMinutes.setText(state.pollMinutes)
+                    }
+                    if (binding.inputTimezone.text?.toString() != state.timezone) {
+                        binding.inputTimezone.setText(state.timezone, false)
+                    }
+                    if (binding.toggleReminders.isChecked != state.notificationsEnabled) {
+                        suppressToggleListener = true
+                        binding.toggleReminders.isChecked = state.notificationsEnabled
+                        suppressToggleListener = false
+                    }
+                    binding.textStatus.text = state.statusText
+                    binding.textLastNotification.text = state.lastNotification
+                        ?: getString(R.string.last_notification_none)
+                }
+            }
+        }
+    }
+
+    private fun setupListeners() {
+        binding.inputLeadHours.doAfterTextChanged { editable ->
+            val text = editable?.toString()?.trim().orEmpty()
+            val current = viewModel.state.value.leadHours
+            if (text.isNotEmpty() && text != current) {
+                text.toDoubleOrNull()?.let { viewModel.onLeadHoursChanged(it) }
+            }
+        }
+        binding.inputPollMinutes.doAfterTextChanged { editable ->
+            val text = editable?.toString()?.trim().orEmpty()
+            val current = viewModel.state.value.pollMinutes
+            if (text.isNotEmpty() && text != current) {
+                text.toLongOrNull()?.let { viewModel.onPollMinutesChanged(it) }
+            }
+        }
+        binding.inputTimezone.setOnItemClickListener { parent, _, position, _ ->
+            val zone = parent.getItemAtPosition(position) as String
+            if (zone != viewModel.state.value.timezone) {
+                viewModel.onTimezoneChanged(zone)
+            }
+        }
+        binding.toggleReminders.setOnCheckedChangeListener { _, isChecked ->
+            if (suppressToggleListener) return@setOnCheckedChangeListener
+            if (isChecked && !hasNotificationPermission()) {
+                suppressToggleListener = true
+                binding.toggleReminders.isChecked = false
+                suppressToggleListener = false
+                requestNotificationPermission()
+                return@setOnCheckedChangeListener
+            }
+            viewModel.onNotificationsToggled(isChecked)
+        }
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            true
+        } else {
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                REQUEST_NOTIFICATIONS
+            )
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_NOTIFICATIONS) {
+            val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+            if (granted) {
+                viewModel.onNotificationsToggled(true)
+            }
+        }
+    }
+
+    companion object {
+        private const val REQUEST_NOTIFICATIONS = 1001
+    }
+}
+
+class MainViewModelFactory(
+    private val application: Application,
+    private val settingsRepository: SettingsRepository,
+    private val reminderRepository: ReminderRepository,
+) : androidx.lifecycle.ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+            return MainViewModel(application, settingsRepository, reminderRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/MainViewModel.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/MainViewModel.kt
@@ -1,0 +1,93 @@
+package com.example.fplnotifier
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import java.text.DecimalFormat
+import java.time.Duration
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+data class UiState(
+    val leadHours: String = "2",
+    val pollMinutes: String = "360",
+    val timezone: String = java.time.ZoneId.systemDefault().id,
+    val notificationsEnabled: Boolean = false,
+    val statusText: String = "",
+    val lastNotification: String? = null,
+)
+
+class MainViewModel(
+    application: Application,
+    private val settingsRepository: SettingsRepository,
+    private val reminderRepository: ReminderRepository,
+) : AndroidViewModel(application) {
+
+    private val _state = MutableStateFlow(UiState())
+    val state: StateFlow<UiState> = _state.asStateFlow()
+
+    private val decimalFormat = DecimalFormat("0.##")
+
+    init {
+        viewModelScope.launch {
+            combine(settingsRepository.settings, reminderRepository.lastNotification) { settings, last ->
+                val status = if (settings.notificationsEnabled) {
+                    application.getString(R.string.notifications_enabled)
+                } else {
+                    application.getString(R.string.notifications_disabled)
+                }
+                UiState(
+                    leadHours = decimalFormat.format(settings.leadHours),
+                    pollMinutes = settings.pollMinutes.toString(),
+                    timezone = settings.timezoneId,
+                    notificationsEnabled = settings.notificationsEnabled,
+                    statusText = status,
+                    lastNotification = last,
+                )
+            }.collect { ui ->
+                _state.value = ui
+            }
+        }
+    }
+
+    fun onLeadHoursChanged(value: Double) {
+        viewModelScope.launch {
+            settingsRepository.updateLeadHours(value)
+            restartIfNeeded()
+        }
+    }
+
+    fun onPollMinutesChanged(value: Long) {
+        viewModelScope.launch {
+            settingsRepository.updatePollMinutes(value)
+            restartIfNeeded()
+        }
+    }
+
+    fun onTimezoneChanged(zoneId: String) {
+        viewModelScope.launch {
+            settingsRepository.updateTimezone(zoneId)
+            restartIfNeeded()
+        }
+    }
+
+    fun onNotificationsToggled(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setNotificationsEnabled(enabled)
+            if (enabled) {
+                DeadlineScheduler.schedule(getApplication(), Duration.ZERO)
+            } else {
+                DeadlineScheduler.cancel(getApplication())
+            }
+        }
+    }
+
+    private suspend fun restartIfNeeded() {
+        if (_state.value.notificationsEnabled) {
+            DeadlineScheduler.schedule(getApplication(), Duration.ZERO)
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/NotificationHelper.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/NotificationHelper.kt
@@ -1,0 +1,89 @@
+package com.example.fplnotifier
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import java.time.Duration
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.math.abs
+
+object NotificationHelper {
+    const val CHANNEL_ID = "fpl_deadlines"
+
+    private val leadFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z")
+
+    fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.app_name),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            channel.description = "Upcoming Fantasy Premier League deadlines"
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    fun sendNotification(
+        context: Context,
+        gameweek: GameweekDeadline,
+        leadTime: Duration,
+        timezone: ZoneId,
+    ) {
+        ensureChannel(context)
+        val formattedLead = formatLead(leadTime)
+        val deadlineLocal = gameweek.deadlineIn(timezone).format(leadFormatter)
+        val title = "FPL deadline in $formattedLead"
+        val message = "${gameweek.name} (GW ${gameweek.eventId}) deadline at $deadlineLocal"
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(gameweek.eventId, notification)
+    }
+
+    private fun formatLead(delta: Duration): String {
+        val totalSeconds = abs(delta.seconds)
+        if (totalSeconds < 60) {
+            return "$totalSeconds seconds"
+        }
+        val minutes = totalSeconds / 60
+        val seconds = totalSeconds % 60
+        val hours = minutes / 60
+        val remainingMinutes = minutes % 60
+        val parts = mutableListOf<String>()
+        if (hours > 0) {
+            parts += if (hours == 1L) "1 hour" else "$hours hours"
+        }
+        if (remainingMinutes > 0) {
+            parts += if (remainingMinutes == 1L) "1 minute" else "$remainingMinutes minutes"
+        }
+        if (seconds > 0 && hours == 0L) {
+            parts += if (seconds == 1L) "1 second" else "$seconds seconds"
+        }
+        return parts.joinToString(" and ")
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/ReminderRepository.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/ReminderRepository.kt
@@ -1,0 +1,96 @@
+package com.example.fplnotifier
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.first
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val Context.reminderDataStore: DataStore<Preferences> by preferencesDataStore(name = "deadline_cache")
+
+private val KEY_SENT = stringPreferencesKey("sent_reminders")
+private val KEY_LAST_NOTIFICATION = stringPreferencesKey("last_notification")
+
+class ReminderRepository(private val context: Context) {
+    private val dataStore = context.reminderDataStore
+
+    data class SentReminder(val eventId: Int, val deadline: Instant)
+
+    val lastNotification: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[KEY_LAST_NOTIFICATION]
+    }
+
+    suspend fun getSentReminders(): List<SentReminder> {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_SENT] ?: return emptyList()
+        val array = JSONArray(raw)
+        val reminders = mutableListOf<SentReminder>()
+        for (i in 0 until array.length()) {
+            val obj = array.optJSONObject(i) ?: continue
+            val eventId = obj.optInt("eventId", -1)
+            val deadlineStr = obj.optString("deadline", null) ?: continue
+            if (eventId <= 0) continue
+            val deadline = try {
+                Instant.parse(deadlineStr)
+            } catch (ex: Exception) {
+                continue
+            }
+            reminders += SentReminder(eventId, deadline)
+        }
+        return reminders
+    }
+
+    suspend fun saveSentReminders(reminders: List<SentReminder>) {
+        val array = JSONArray()
+        reminders.forEach { reminder ->
+            val obj = JSONObject()
+            obj.put("eventId", reminder.eventId)
+            obj.put("deadline", reminder.deadline.toString())
+            array.put(obj)
+        }
+        dataStore.edit { prefs ->
+            if (reminders.isEmpty()) {
+                prefs.remove(KEY_SENT)
+            } else {
+                prefs[KEY_SENT] = array.toString()
+            }
+        }
+    }
+
+    suspend fun recordNotification(gameweek: GameweekDeadline, zoneId: ZoneId) {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z")
+        val message = buildString {
+            append("Sent reminder for ")
+            append(gameweek.name)
+            append(" (GW ")
+            append(gameweek.eventId)
+            append(") at ")
+            append(gameweek.deadlineIn(zoneId).format(formatter))
+        }
+        dataStore.edit { prefs ->
+            prefs[KEY_LAST_NOTIFICATION] = message
+        }
+    }
+
+    suspend fun clearLastNotification() {
+        dataStore.edit { prefs ->
+            prefs.remove(KEY_LAST_NOTIFICATION)
+        }
+    }
+
+    fun prune(reminders: List<SentReminder>, now: Instant, pollInterval: Duration): List<SentReminder> {
+        return reminders.filter { reminder ->
+            now.isBefore(reminder.deadline.plus(pollInterval))
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/SettingsRepository.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/SettingsRepository.kt
@@ -1,0 +1,66 @@
+package com.example.fplnotifier
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.ZoneId
+
+private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "user_settings")
+
+private val KEY_LEAD_HOURS = doublePreferencesKey("lead_hours")
+private val KEY_POLL_MINUTES = longPreferencesKey("poll_minutes")
+private val KEY_TIMEZONE = stringPreferencesKey("timezone")
+private val KEY_NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
+
+data class UserSettings(
+    val leadHours: Double,
+    val pollMinutes: Long,
+    val timezoneId: String,
+    val notificationsEnabled: Boolean,
+)
+
+class SettingsRepository(private val context: Context) {
+    private val dataStore = context.settingsDataStore
+
+    val settings: Flow<UserSettings> = dataStore.data.map { prefs ->
+        val defaultTz = ZoneId.systemDefault().id
+        UserSettings(
+            leadHours = prefs[KEY_LEAD_HOURS] ?: 2.0,
+            pollMinutes = prefs[KEY_POLL_MINUTES] ?: 360,
+            timezoneId = prefs[KEY_TIMEZONE] ?: defaultTz,
+            notificationsEnabled = prefs[KEY_NOTIFICATIONS_ENABLED] ?: false,
+        )
+    }
+
+    suspend fun updateLeadHours(value: Double) {
+        dataStore.edit { prefs ->
+            prefs[KEY_LEAD_HOURS] = value.coerceAtLeast(0.1)
+        }
+    }
+
+    suspend fun updatePollMinutes(value: Long) {
+        dataStore.edit { prefs ->
+            prefs[KEY_POLL_MINUTES] = value.coerceAtLeast(1L)
+        }
+    }
+
+    suspend fun updateTimezone(zoneId: String) {
+        dataStore.edit { prefs ->
+            prefs[KEY_TIMEZONE] = zoneId
+        }
+    }
+
+    suspend fun setNotificationsEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_NOTIFICATIONS_ENABLED] = enabled
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/example/fplnotifier/model.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/model.kt
@@ -1,0 +1,24 @@
+package com.example.fplnotifier
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/** Represents a Fantasy Premier League gameweek deadline. */
+data class GameweekDeadline(
+    val eventId: Int,
+    val name: String,
+    val deadline: Instant,
+) {
+    fun deadlineIn(zoneId: ZoneId): ZonedDateTime = ZonedDateTime.ofInstant(deadline, zoneId)
+}
+
+object DeadlineFormatter {
+    private val deadlineFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z")
+
+    fun formatDeadline(deadline: GameweekDeadline, zoneId: ZoneId): String {
+        return deadline.deadlineIn(zoneId).format(deadlineFormatter)
+    }
+}

--- a/android-app/app/src/main/res/layout/activity_main.xml
+++ b/android-app/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/lead_hours_label">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputLeadHours"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="numberDecimal"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/poll_minutes_label">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputPollMinutes"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:hint="@string/timezone_label">
+
+            <AutoCompleteTextView
+                android:id="@+id/inputTimezone"
+                style="@style/Widget.Material3.AutoCompleteTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/toggleReminders"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:text="@string/enable_reminders" />
+
+        <TextView
+            android:id="@+id/textStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="@android:color/black" />
+
+        <TextView
+            android:id="@+id/textLastNotification"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/last_notification_none"
+            android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/save_changes"
+            android:textAppearance="?attr/textAppearanceBodySmall" />
+    </LinearLayout>
+</ScrollView>

--- a/android-app/app/src/main/res/values-night/themes.xml
+++ b/android-app/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,3 @@
+<resources>
+    <style name="Theme.FplNotifier" parent="Theme.Material3.DayNight.NoActionBar" />
+</resources>

--- a/android-app/app/src/main/res/values/colors.xml
+++ b/android-app/app/src/main/res/values/colors.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="purple_500">#6750A4</color>
+</resources>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+    <string name="app_name">FPL Notifier</string>
+    <string name="lead_hours_label">Lead time (hours)</string>
+    <string name="poll_minutes_label">Polling interval (minutes)</string>
+    <string name="timezone_label">Timezone</string>
+    <string name="enable_reminders">Enable reminders</string>
+    <string name="status_heading">Status</string>
+    <string name="last_notification_none">No reminders sent yet.</string>
+    <string name="save_changes">Settings are saved automatically.</string>
+    <string name="notifications_disabled">Background reminders are disabled.</string>
+    <string name="notifications_enabled">Background reminders are enabled.</string>
+</resources>

--- a/android-app/app/src/main/res/values/themes.xml
+++ b/android-app/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.FplNotifier" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- Customize your light theme here. -->
+        <item name="colorPrimary">@color/purple_500</item>
+    </style>
+</resources>

--- a/android-app/app/src/test/java/com/example/fplnotifier/FplApiRepositoryTest.kt
+++ b/android-app/app/src/test/java/com/example/fplnotifier/FplApiRepositoryTest.kt
@@ -1,0 +1,62 @@
+package com.example.fplnotifier
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FplApiRepositoryTest {
+
+    @Test
+    fun `parses upcoming deadlines and sorts by date`() = runTest {
+        val now = Instant.parse("2024-08-10T10:00:00Z")
+        val json = """
+            {
+              "events": [
+                {"id": 2, "name": "Gameweek 2", "deadline_time": "2024-08-19T17:30:00Z"},
+                {"id": 1, "name": "Gameweek 1", "deadline_time": "2024-08-16T17:30:00Z"}
+              ]
+            }
+        """.trimIndent()
+        val repository = FplApiRepository { json }
+
+        val deadlines = repository.getUpcomingDeadlines(now)
+
+        assertEquals(2, deadlines.size)
+        assertEquals(1, deadlines.first().eventId)
+        assertTrue(deadlines.first().deadline.isAfter(now))
+        assertTrue(deadlines[1].deadline.isAfter(deadlines.first().deadline))
+    }
+
+    @Test
+    fun `filters past deadlines and invalid entries`() = runTest {
+        val now = Instant.parse("2024-08-20T10:00:00Z")
+        val json = """
+            {
+              "events": [
+                {"id": 1, "name": "Gameweek 1", "deadline_time": "2024-08-16T17:30:00Z"},
+                {"id": 2, "name": "Gameweek 2", "deadline_time": "2024-08-22T17:30:00Z"},
+                {"id": 3, "name": "Broken", "deadline_time": null}
+              ]
+            }
+        """.trimIndent()
+        val repository = FplApiRepository { json }
+
+        val deadlines = repository.getUpcomingDeadlines(now)
+
+        assertEquals(1, deadlines.size)
+        assertEquals(2, deadlines.first().eventId)
+        assertEquals("Gameweek 2", deadlines.first().name)
+    }
+
+    @Test
+    fun `parseDeadline handles trailing Z`() {
+        val instant = parseDeadline("2024-08-16T18:30:00Z")
+        assertEquals(0, ChronoUnit.SECONDS.between(
+            Instant.parse("2024-08-16T18:30:00Z"),
+            instant
+        ))
+    }
+}

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+}

--- a/android-app/gradle.properties
+++ b/android-app/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+kotlin.code.style=official

--- a/android-app/gradlew
+++ b/android-app/gradlew
@@ -1,0 +1,4 @@
+#!/bin/sh
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit 1
+exec gradle "$@"

--- a/android-app/gradlew.bat
+++ b/android-app/gradlew.bat
@@ -1,0 +1,4 @@
+@echo off
+set DIR=%~dp0
+cd /d %DIR%
+call gradle %*

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "FplNotifier"
+include(":app")


### PR DESCRIPTION
## Summary
- scaffold a Kotlin Android application that mirrors the CLI configuration for lead time, polling interval, and timezone
- implement repository, DataStore-backed settings, WorkManager scheduling, and NotificationCompat delivery for FPL deadlines
- document the Android workflow and expose parser unit tests for the bootstrap-static API

## Testing
- `gradle test` *(fails: Android Gradle plugin could not be downloaded in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc912671f08332878e5c362decd44c