### PR TITLE
Add SwiftUI iOS client with scheduler and data layer tests

### DIFF
--- a/ios-app/FplNotifier.xcodeproj/project.pbxproj
+++ b/ios-app/FplNotifier.xcodeproj/project.pbxproj
@@ -1,0 +1,375 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+3E1D4A5A2B0E45C8008B9A22 /* FplNotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A4F2B0E45C8008B9A22; };
+3E1D4A5B2B0E45C8008B9A22 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A502B0E45C8008B9A22; };
+3E1D4A5C2B0E45C8008B9A22 /* FplApiRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A512B0E45C8008B9A22; };
+3E1D4A5D2B0E45C8008B9A22 /* GameweekDeadline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A522B0E45C8008B9A22; };
+3E1D4A5E2B0E45C8008B9A22 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A532B0E45C8008B9A22; };
+3E1D4A5F2B0E45C8008B9A22 /* ReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A542B0E45C8008B9A22; };
+3E1D4A602B0E45C8008B9A22 /* DeadlineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A552B0E45C8008B9A22; };
+3E1D4A612B0E45C8008B9A22 /* NotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A562B0E45C8008B9A22; };
+3E1D4A622B0E45C8008B9A22 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A572B0E45C8008B9A22; };
+3E1D4A632B0E45C8008B9A22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3E1D4A582B0E45C8008B9A22; };
+3E1D4A6A2B0E45C8008B9A22 /* GameweekDeadlineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1D4A652B0E45C8008B9A22; };
+3E1D4A6B2B0E45C8008B9A22 /* bootstrap.json in Resources */ = {isa = PBXBuildFile; fileRef = 3E1D4A662B0E45C8008B9A22; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+3E1D4A3A2B0E45B1008B9A22 /* FplNotifier.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FplNotifier.app; sourceTree = BUILT_PRODUCTS_DIR; };
+3E1D4A3B2B0E45B1008B9A22 /* FplNotifierTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FplNotifierTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+3E1D4A4F2B0E45C8008B9A22 /* FplNotifierApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FplNotifierApp.swift; sourceTree = "<group>"; };
+3E1D4A502B0E45C8008B9A22 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+3E1D4A512B0E45C8008B9A22 /* FplApiRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FplApiRepository.swift; sourceTree = "<group>"; };
+3E1D4A522B0E45C8008B9A22 /* GameweekDeadline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameweekDeadline.swift; sourceTree = "<group>"; };
+3E1D4A532B0E45C8008B9A22 /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
+3E1D4A542B0E45C8008B9A22 /* ReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderStore.swift; sourceTree = "<group>"; };
+3E1D4A552B0E45C8008B9A22 /* DeadlineScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeadlineScheduler.swift; sourceTree = "<group>"; };
+3E1D4A562B0E45C8008B9A22 /* NotificationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHelper.swift; sourceTree = "<group>"; };
+3E1D4A572B0E45C8008B9A22 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+3E1D4A582B0E45C8008B9A22 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+3E1D4A592B0E45C8008B9A22 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+3E1D4A652B0E45C8008B9A22 /* GameweekDeadlineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameweekDeadlineTests.swift; sourceTree = "<group>"; };
+3E1D4A662B0E45C8008B9A22 /* bootstrap.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = bootstrap.json; sourceTree = "<group>"; };
+3E1D4A672B0E45C8008B9A22 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+3E1D4A342B0E45B1008B9A22 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (
+);
+runOnlyForDeploymentPostprocessing = 0; };
+3E1D4A3D2B0E45B1008B9A22 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (
+);
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+3E1D4A312B0E45A0008B9A22 = {isa = PBXGroup; children = (
+3E1D4A4B2B0E45C8008B9A22 /* FplNotifier */, 
+3E1D4A642B0E45C8008B9A22 /* Tests */, 
+3E1D4A3A2B0E45B1008B9A22 /* Products */,
+); sourceTree = "<group>"; };
+3E1D4A3A2B0E45B1008B9A22 /* Products */ = {isa = PBXGroup; children = (
+3E1D4A3A2B0E45B1008B9A22 /* FplNotifier.app */,
+3E1D4A3B2B0E45B1008B9A22 /* FplNotifierTests.xctest */,
+); name = Products; sourceTree = "<group>"; };
+3E1D4A4B2B0E45C8008B9A22 /* FplNotifier */ = {isa = PBXGroup; children = (
+3E1D4A4C2B0E45C8008B9A22 /* Views */, 
+3E1D4A4D2B0E45C8008B9A22 /* ViewModels */, 
+3E1D4A4E2B0E45C8008B9A22 /* Data */, 
+3E1D4A5A2B0E45C8008B9A22 /* Scheduling */, 
+3E1D4A582B0E45C8008B9A22 /* Assets.xcassets */, 
+3E1D4A592B0E45C8008B9A22 /* Info.plist */,
+); path = FplNotifier; sourceTree = "<group>"; };
+3E1D4A4C2B0E45C8008B9A22 /* Views */ = {isa = PBXGroup; children = (
+3E1D4A502B0E45C8008B9A22 /* ContentView.swift */, 
+3E1D4A4F2B0E45C8008B9A22 /* FplNotifierApp.swift */,
+); path = Views; sourceTree = "<group>"; };
+3E1D4A4D2B0E45C8008B9A22 /* ViewModels */ = {isa = PBXGroup; children = (
+3E1D4A572B0E45C8008B9A22 /* MainViewModel.swift */,
+); path = ViewModels; sourceTree = "<group>"; };
+3E1D4A4E2B0E45C8008B9A22 /* Data */ = {isa = PBXGroup; children = (
+3E1D4A512B0E45C8008B9A22 /* FplApiRepository.swift */, 
+3E1D4A522B0E45C8008B9A22 /* GameweekDeadline.swift */, 
+3E1D4A532B0E45C8008B9A22 /* SettingsStore.swift */, 
+3E1D4A542B0E45C8008B9A22 /* ReminderStore.swift */,
+); path = Data; sourceTree = "<group>"; };
+3E1D4A5A2B0E45C8008B9A22 /* Scheduling */ = {isa = PBXGroup; children = (
+3E1D4A552B0E45C8008B9A22 /* DeadlineScheduler.swift */, 
+3E1D4A562B0E45C8008B9A22 /* NotificationHelper.swift */,
+); path = Scheduling; sourceTree = "<group>"; };
+3E1D4A642B0E45C8008B9A22 /* Tests */ = {isa = PBXGroup; children = (
+3E1D4A652B0E45C8008B9A22 /* GameweekDeadlineTests.swift */, 
+3E1D4A682B0E45C8008B9A22 /* Fixtures */, 
+3E1D4A672B0E45C8008B9A22 /* Info.plist */,
+); path = Tests/FplNotifierTests; sourceTree = "<group>"; };
+3E1D4A682B0E45C8008B9A22 /* Fixtures */ = {isa = PBXGroup; children = (
+3E1D4A662B0E45C8008B9A22 /* bootstrap.json */,
+); path = Fixtures; sourceTree = "<group>"; };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+3E1D4A332B0E45B1008B9A22 /* FplNotifier */ = {isa = PBXNativeTarget; buildConfigurationList = 3E1D4A472B0E45B1008B9A22 /* Build configuration list for PBXNativeTarget "FplNotifier" */; buildPhases = (
+3E1D4A322B0E45B1008B9A22 /* Sources */, 
+3E1D4A342B0E45B1008B9A22 /* Frameworks */, 
+3E1D4A352B0E45B1008B9A22 /* Resources */,
+); buildRules = (
+);
+dependencies = (
+);
+name = FplNotifier;
+productName = FplNotifier;
+productReference = 3E1D4A3A2B0E45B1008B9A22 /* FplNotifier.app */;
+productType = "com.apple.product-type.application";
+};
+3E1D4A3C2B0E45B1008B9A22 /* FplNotifierTests */ = {isa = PBXNativeTarget; buildConfigurationList = 3E1D4A482B0E45B1008B9A22 /* Build configuration list for PBXNativeTarget "FplNotifierTests" */; buildPhases = (
+3E1D4A3F2B0E45B1008B9A22 /* Sources */, 
+3E1D4A3D2B0E45B1008B9A22 /* Frameworks */, 
+3E1D4A3E2B0E45B1008B9A22 /* Resources */,
+);
+dependencies = (
+3E1D4A402B0E45B1008B9A22 /* PBXTargetDependency */,
+);
+name = FplNotifierTests;
+productName = FplNotifierTests;
+productReference = 3E1D4A3B2B0E45B1008B9A22 /* FplNotifierTests.xctest */;
+productType = "com.apple.product-type.bundle.unit-test";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+3E1D4A302B0E45A0008B9A22 /* Project object */ = {isa = PBXProject; attributes = {
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+TargetAttributes = {
+3E1D4A332B0E45B1008B9A22 = {
+CreatedOnToolsVersion = 15.0;
+};
+3E1D4A3C2B0E45B1008B9A22 = {
+CreatedOnToolsVersion = 15.0;
+TestTargetID = 3E1D4A332B0E45B1008B9A22;
+};
+};
+};
+buildConfigurationList = 3E1D4A462B0E45B1008B9A22 /* Build configuration list for PBXProject "FplNotifier" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+mainGroup = 3E1D4A312B0E45A0008B9A22;
+productRefGroup = 3E1D4A3A2B0E45B1008B9A22 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+3E1D4A332B0E45B1008B9A22 /* FplNotifier */,
+3E1D4A3C2B0E45B1008B9A22 /* FplNotifierTests */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+3E1D4A352B0E45B1008B9A22 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (
+3E1D4A632B0E45C8008B9A22 /* Assets.xcassets in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0; };
+3E1D4A3E2B0E45B1008B9A22 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (
+3E1D4A6B2B0E45C8008B9A22 /* bootstrap.json in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+3E1D4A322B0E45B1008B9A22 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
+3E1D4A622B0E45C8008B9A22 /* MainViewModel.swift in Sources */,
+3E1D4A5F2B0E45C8008B9A22 /* ReminderStore.swift in Sources */,
+3E1D4A602B0E45C8008B9A22 /* DeadlineScheduler.swift in Sources */,
+3E1D4A612B0E45C8008B9A22 /* NotificationHelper.swift in Sources */,
+3E1D4A5C2B0E45C8008B9A22 /* FplApiRepository.swift in Sources */,
+3E1D4A5A2B0E45C8008B9A22 /* FplNotifierApp.swift in Sources */,
+3E1D4A5B2B0E45C8008B9A22 /* ContentView.swift in Sources */,
+3E1D4A5E2B0E45C8008B9A22 /* SettingsStore.swift in Sources */,
+3E1D4A5D2B0E45C8008B9A22 /* GameweekDeadline.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0; };
+3E1D4A3F2B0E45B1008B9A22 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
+3E1D4A6A2B0E45C8008B9A22 /* GameweekDeadlineTests.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+3E1D4A402B0E45B1008B9A22 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = 3E1D4A332B0E45B1008B9A22 /* FplNotifier */; targetProxy = 3E1D4A412B0E45B1008B9A22 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+3E1D4A412B0E45B1008B9A22 /* PBXContainerItemProxy */ = {isa = PBXContainerItemProxy; containerPortal = 3E1D4A302B0E45A0008B9A22 /* Project object */; proxyType = 1; remoteGlobalIDString = 3E1D4A332B0E45B1008B9A22; remoteInfo = FplNotifier; };
+/* End PBXContainerItemProxy section */
+
+/* Begin XCBuildConfiguration section */
+3E1D4A422B0E45B1008B9A22 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_ENABLE_OBJC_WEAK = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+TARGETED_DEVICE_FAMILY = "1";
+}; name = Debug; };
+3E1D4A432B0E45B1008B9A22 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_ENABLE_OBJC_WEAK = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+TARGETED_DEVICE_FAMILY = "1";
+}; name = Release; };
+3E1D4A492B0E45B1008B9A22 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = FplNotifier/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.FplNotifier;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = 1;
+}; name = Debug; };
+3E1D4A4A2B0E45B1008B9A22 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = FplNotifier/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.FplNotifier;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = 1;
+}; name = Release; };
+3E1D4A4B2B0E45B1008B9A22 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = Tests/FplNotifierTests/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.FplNotifierTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = NO;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = 1;
+}; name = Debug; };
+3E1D4A4C2B0E45B1008B9A22 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = Tests/FplNotifierTests/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.example.FplNotifierTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = NO;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = 1;
+}; name = Release; };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+3E1D4A462B0E45B1008B9A22 /* Build configuration list for PBXProject "FplNotifier" */ = {isa = XCConfigurationList; buildConfigurations = (
+3E1D4A422B0E45B1008B9A22 /* Debug */,
+3E1D4A432B0E45B1008B9A22 /* Release */,
+); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+3E1D4A472B0E45B1008B9A22 /* Build configuration list for PBXNativeTarget "FplNotifier" */ = {isa = XCConfigurationList; buildConfigurations = (
+3E1D4A492B0E45B1008B9A22 /* Debug */,
+3E1D4A4A2B0E45B1008B9A22 /* Release */,
+); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+3E1D4A482B0E45B1008B9A22 /* Build configuration list for PBXNativeTarget "FplNotifierTests" */ = {isa = XCConfigurationList; buildConfigurations = (
+3E1D4A4B2B0E45B1008B9A22 /* Debug */,
+3E1D4A4C2B0E45B1008B9A22 /* Release */,
+); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+
+};
+rootObject = 3E1D4A302B0E45A0008B9A22 /* Project object */;
+}

--- a/ios-app/FplNotifier/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios-app/FplNotifier/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-app/FplNotifier/Assets.xcassets/Contents.json
+++ b/ios-app/FplNotifier/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-app/FplNotifier/Data/FplApiRepository.swift
+++ b/ios-app/FplNotifier/Data/FplApiRepository.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+final class FplApiRepository {
+    typealias DataFetcher = @Sendable (URL) async throws -> Data
+
+    private static let apiURL = URL(string: "https://fantasy.premierleague.com/api/bootstrap-static/")!
+    private let fetcher: DataFetcher
+    private let decoder: JSONDecoder
+    private let isoFormatters: [ISO8601DateFormatter]
+
+    init(fetcher: DataFetcher? = nil) {
+        self.fetcher = fetcher ?? FplApiRepository.defaultFetcher
+        self.decoder = JSONDecoder()
+        self.isoFormatters = [
+            {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                return formatter
+            }(),
+            {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime]
+                return formatter
+            }()
+        ]
+    }
+
+    func getUpcomingDeadlines(now: Date = Date()) async throws -> [GameweekDeadline] {
+        let data = try await fetcher(Self.apiURL)
+        let payload = try decoder.decode(BootstrapStaticResponse.self, from: data)
+        return payload.events
+            .compactMap { event -> GameweekDeadline? in
+                guard let id = event.id, id > 0 else { return nil }
+                guard let rawDeadline = event.deadlineTime,
+                      let deadline = try? parseDeadline(rawDeadline),
+                      deadline > now else { return nil }
+                let name = event.name ?? event.event ?? "Gameweek \(id)"
+                return GameweekDeadline(eventId: id, name: name, deadline: deadline)
+            }
+            .sorted { $0.deadline < $1.deadline }
+    }
+
+    private func parseDeadline(_ raw: String) throws -> Date {
+        for formatter in isoFormatters {
+            if let date = formatter.date(from: raw) {
+                return date
+            }
+        }
+        if raw.uppercased().hasSuffix("Z") {
+            let adjusted = String(raw.dropLast()) + "+00:00"
+            for formatter in isoFormatters {
+                if let date = formatter.date(from: adjusted) {
+                    return date
+                }
+            }
+        }
+        throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Unable to parse deadline \(raw)"))
+    }
+
+    private static func defaultFetcher(url: URL) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+}
+
+private struct BootstrapStaticResponse: Decodable {
+    let events: [EventPayload]
+
+    struct EventPayload: Decodable {
+        let id: Int?
+        let name: String?
+        let event: String?
+        let deadlineTime: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case event
+            case deadlineTime = "deadline_time"
+        }
+    }
+}

--- a/ios-app/FplNotifier/Data/GameweekDeadline.swift
+++ b/ios-app/FplNotifier/Data/GameweekDeadline.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct GameweekDeadline: Identifiable, Equatable {
+    let eventId: Int
+    let name: String
+    let deadline: Date
+
+    var id: Int { eventId }
+
+    func formattedDeadline(in timeZone: TimeZone) -> String {
+        DeadlineFormatter.format(self, in: timeZone)
+    }
+}
+
+enum DeadlineFormatter {
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm z"
+        formatter.timeZone = .current
+        return formatter
+    }()
+
+    static func string(from deadline: Date, timeZone: TimeZone) -> String {
+        formatter.timeZone = timeZone
+        return formatter.string(from: deadline)
+    }
+
+    static func format(_ deadline: GameweekDeadline, in timeZone: TimeZone) -> String {
+        string(from: deadline.deadline, timeZone: timeZone)
+    }
+}

--- a/ios-app/FplNotifier/Data/ReminderStore.swift
+++ b/ios-app/FplNotifier/Data/ReminderStore.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+@MainActor
+final class ReminderStore: ObservableObject {
+    struct SentReminder: Codable, Equatable {
+        let eventId: Int
+        let deadline: Date
+    }
+
+    @Published private(set) var lastNotification: String?
+
+    private let defaults: UserDefaults
+    private let sentKey = "com.example.fplnotifier.sentReminders"
+    private let lastKey = "com.example.fplnotifier.lastNotification"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private var cachedReminders: [SentReminder]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: sentKey),
+           let reminders = try? decoder.decode([SentReminder].self, from: data) {
+            cachedReminders = reminders
+        } else {
+            cachedReminders = []
+        }
+        lastNotification = defaults.string(forKey: lastKey)
+    }
+
+    var sentReminders: [SentReminder] {
+        cachedReminders
+    }
+
+    func saveSentReminders(_ reminders: [SentReminder]) {
+        cachedReminders = reminders
+        if reminders.isEmpty {
+            defaults.removeObject(forKey: sentKey)
+        } else if let data = try? encoder.encode(reminders) {
+            defaults.set(data, forKey: sentKey)
+        }
+    }
+
+    func prune(reminders: [SentReminder], now: Date, pollInterval: TimeInterval) -> [SentReminder] {
+        reminders.filter { reminder in
+            now < reminder.deadline.addingTimeInterval(pollInterval)
+        }
+    }
+
+    func recordNotification(for gameweek: GameweekDeadline, timezone: TimeZone) {
+        let message = "Sent reminder for \(gameweek.name) (GW \(gameweek.eventId)) at \(DeadlineFormatter.format(gameweek, in: timezone))"
+        lastNotification = message
+        defaults.set(message, forKey: lastKey)
+    }
+
+    func clearLastNotification() {
+        lastNotification = nil
+        defaults.removeObject(forKey: lastKey)
+    }
+}

--- a/ios-app/FplNotifier/Data/SettingsStore.swift
+++ b/ios-app/FplNotifier/Data/SettingsStore.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+@MainActor
+final class SettingsStore: ObservableObject {
+    struct UserSettings: Codable {
+        var leadHours: Double
+        var pollMinutes: Int
+        var timezoneId: String
+        var notificationsEnabled: Bool
+    }
+
+    @Published private(set) var userSettings: UserSettings
+
+    private let defaults: UserDefaults
+    private let storageKey = "com.example.fplnotifier.settings"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: storageKey),
+           let stored = try? decoder.decode(UserSettings.self, from: data) {
+            self.userSettings = stored
+        } else {
+            let fallback = UserSettings(
+                leadHours: 2.0,
+                pollMinutes: 360,
+                timezoneId: TimeZone.current.identifier,
+                notificationsEnabled: false
+            )
+            self.userSettings = fallback
+        }
+    }
+
+    func updateLeadHours(_ value: Double) {
+        let newValue = max(value, 0.1)
+        guard userSettings.leadHours != newValue else { return }
+        userSettings.leadHours = newValue
+        persist()
+    }
+
+    func updatePollMinutes(_ value: Int) {
+        let newValue = max(value, 1)
+        guard userSettings.pollMinutes != newValue else { return }
+        userSettings.pollMinutes = newValue
+        persist()
+    }
+
+    func updateTimezone(_ identifier: String) {
+        guard userSettings.timezoneId != identifier else { return }
+        userSettings.timezoneId = identifier
+        persist()
+    }
+
+    func setNotificationsEnabled(_ enabled: Bool) {
+        guard userSettings.notificationsEnabled != enabled else { return }
+        userSettings.notificationsEnabled = enabled
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? encoder.encode(userSettings) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/ios-app/FplNotifier/Info.plist
+++ b/ios-app/FplNotifier/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDevelopmentRegion</key>
+<string>$(DEVELOPMENT_LANGUAGE)</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleName</key>
+<string>$(PRODUCT_NAME)</string>
+<key>CFBundlePackageType</key>
+<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+<key>CFBundleShortVersionString</key>
+<string>1.0</string>
+<key>CFBundleVersion</key>
+<string>1</string>
+<key>LSRequiresIPhoneOS</key>
+<true/>
+<key>UILaunchScreen</key>
+<dict/>
+<key>UIApplicationSceneManifest</key>
+<dict>
+<key>UIApplicationSupportsMultipleScenes</key>
+<false/>
+<key>UISceneConfigurations</key>
+<dict>
+<key>UIWindowSceneSessionRoleApplication</key>
+<array>
+<dict>
+<key>UISceneConfigurationName</key>
+<string>Default Configuration</string>
+<key>UISceneDelegateClassName</key>
+<string></string>
+</dict>
+</array>
+</dict>
+</dict>
+</dict>
+</plist>

--- a/ios-app/FplNotifier/Scheduling/DeadlineScheduler.swift
+++ b/ios-app/FplNotifier/Scheduling/DeadlineScheduler.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+@MainActor
+final class DeadlineScheduler: ObservableObject {
+    struct PlannedNotification: Equatable {
+        let notifyAt: Date
+        let gameweek: GameweekDeadline
+    }
+
+    @Published private(set) var plannedNotification: PlannedNotification?
+
+    private let settingsStore: SettingsStore
+    private let reminderStore: ReminderStore
+    private let apiRepository: FplApiRepository
+    private let dateProvider: () -> Date
+
+    private var workerTask: Task<Void, Never>?
+
+    init(
+        settingsStore: SettingsStore,
+        reminderStore: ReminderStore,
+        apiRepository: FplApiRepository = FplApiRepository(),
+        dateProvider: @escaping () -> Date = Date.init
+    ) {
+        self.settingsStore = settingsStore
+        self.reminderStore = reminderStore
+        self.apiRepository = apiRepository
+        self.dateProvider = dateProvider
+    }
+
+    func ensureRunningIfNeeded() {
+        if settingsStore.userSettings.notificationsEnabled {
+            start()
+        } else {
+            cancel()
+        }
+    }
+
+    func restart() {
+        cancel()
+        ensureRunningIfNeeded()
+    }
+
+    func cancel() {
+        workerTask?.cancel()
+        workerTask = nil
+        plannedNotification = nil
+    }
+
+    func requestAuthorizationIfNeeded() async -> Bool {
+        await NotificationHelper.requestAuthorizationIfNeeded()
+    }
+
+    private func start() {
+        guard workerTask == nil else { return }
+        workerTask = Task { [weak self] in
+            await self?.loop()
+        }
+    }
+
+    private func loop() async {
+        while let delay = await runCycle(), delay >= 0 {
+            if delay == 0 {
+                continue
+            }
+            do {
+                try await Task.sleep(nanoseconds: UInt64(max(delay, 1) * 1_000_000_000))
+            } catch {
+                break
+            }
+        }
+        workerTask = nil
+    }
+
+    private func runCycle() async -> TimeInterval? {
+        let settings = settingsStore.userSettings
+        if !settings.notificationsEnabled {
+            reminderStore.clearLastNotification()
+            plannedNotification = nil
+            return nil
+        }
+
+        let now = dateProvider()
+        let pollInterval = max(TimeInterval(settings.pollMinutes * 60), 60)
+        let leadInterval = max(settings.leadHours, 0.1) * 3600
+        let timezone = TimeZone(identifier: settings.timezoneId) ?? .current
+
+        var sent = reminderStore.sentReminders
+        sent = reminderStore.prune(reminders: sent, now: now, pollInterval: pollInterval)
+
+        do {
+            let deadlines = try await apiRepository.getUpcomingDeadlines(now: now)
+            reminderStore.saveSentReminders(sent)
+            guard let upcoming = deadlines.first else {
+                plannedNotification = nil
+                return pollInterval
+            }
+            let notifyAt = upcoming.deadline.addingTimeInterval(-leadInterval)
+            let alreadySent = sent.contains { $0.eventId == upcoming.eventId }
+            if notifyAt <= now {
+                plannedNotification = nil
+                if !alreadySent {
+                    await NotificationHelper.sendNotification(for: upcoming, leadTime: leadInterval, timezone: timezone)
+                    sent.append(ReminderStore.SentReminder(eventId: upcoming.eventId, deadline: upcoming.deadline))
+                    reminderStore.saveSentReminders(sent)
+                    reminderStore.recordNotification(for: upcoming, timezone: timezone)
+                }
+                return pollInterval
+            } else {
+                plannedNotification = PlannedNotification(notifyAt: notifyAt, gameweek: upcoming)
+                reminderStore.saveSentReminders(sent)
+                let wait = min(pollInterval, notifyAt.timeIntervalSince(now))
+                return max(wait, 1)
+            }
+        } catch {
+            reminderStore.saveSentReminders(sent)
+            return pollInterval
+        }
+    }
+}

--- a/ios-app/FplNotifier/Scheduling/NotificationHelper.swift
+++ b/ios-app/FplNotifier/Scheduling/NotificationHelper.swift
@@ -1,0 +1,89 @@
+import Foundation
+import UserNotifications
+
+enum NotificationHelper {
+    static func requestAuthorizationIfNeeded(center: UNUserNotificationCenter = .current()) async -> Bool {
+        let settings = await withCheckedContinuation { continuation in
+            center.getNotificationSettings { notificationSettings in
+                continuation.resume(returning: notificationSettings)
+            }
+        }
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .denied:
+            return false
+        case .notDetermined:
+            do {
+                return try await withCheckedThrowingContinuation { continuation in
+                    center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume(returning: granted)
+                        }
+                    }
+                }
+            } catch {
+                return false
+            }
+        @unknown default:
+            return false
+        }
+    }
+
+    static func sendNotification(
+        for gameweek: GameweekDeadline,
+        leadTime: TimeInterval,
+        timezone: TimeZone,
+        center: UNUserNotificationCenter = .current()
+    ) async {
+        let content = UNMutableNotificationContent()
+        let leadDescription = formatLeadTime(leadTime)
+        content.title = "FPL deadline in \(leadDescription)"
+        content.body = "\(gameweek.name) (GW \(gameweek.eventId)) deadline at \(DeadlineFormatter.format(gameweek, in: timezone))"
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "fpl_deadline_\(gameweek.eventId)",
+            content: content,
+            trigger: nil
+        )
+
+        _ = try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            center.add(request) { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    private static func formatLeadTime(_ interval: TimeInterval) -> String {
+        let totalSeconds = Int(abs(interval))
+        if totalSeconds < 60 {
+            return secondsDescription(totalSeconds)
+        }
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+        var parts: [String] = []
+        if hours > 0 {
+            parts.append(hours == 1 ? "1 hour" : "\(hours) hours")
+        }
+        if remainingMinutes > 0 {
+            parts.append(remainingMinutes == 1 ? "1 minute" : "\(remainingMinutes) minutes")
+        }
+        if seconds > 0 && hours == 0 {
+            parts.append(secondsDescription(seconds))
+        }
+        return parts.joined(separator: " and ")
+    }
+
+    private static func secondsDescription(_ seconds: Int) -> String {
+        return seconds == 1 ? "1 second" : "\(seconds) seconds"
+    }
+}

--- a/ios-app/FplNotifier/ViewModels/MainViewModel.swift
+++ b/ios-app/FplNotifier/ViewModels/MainViewModel.swift
@@ -1,0 +1,148 @@
+import Combine
+import Foundation
+import SwiftUI
+
+@MainActor
+final class MainViewModel: ObservableObject {
+    struct UiState {
+        var leadHours: Double
+        var pollMinutes: Int
+        var timezoneId: String
+        var notificationsEnabled: Bool
+        var statusText: String
+        var nextNotificationText: String?
+        var lastNotification: String?
+    }
+
+    @Published private(set) var state: UiState
+    let timezones: [String]
+
+    private let settingsStore: SettingsStore
+    private let reminderStore: ReminderStore
+    private let scheduler: DeadlineScheduler
+    private var cancellables: Set<AnyCancellable> = []
+    private var plannedNotification: DeadlineScheduler.PlannedNotification?
+    private let numberFormatter: NumberFormatter
+
+    init(settingsStore: SettingsStore, reminderStore: ReminderStore, scheduler: DeadlineScheduler) {
+        self.settingsStore = settingsStore
+        self.reminderStore = reminderStore
+        self.scheduler = scheduler
+        let settings = settingsStore.userSettings
+        let status = MainViewModel.statusText(enabled: settings.notificationsEnabled)
+        self.state = UiState(
+            leadHours: settings.leadHours,
+            pollMinutes: settings.pollMinutes,
+            timezoneId: settings.timezoneId,
+            notificationsEnabled: settings.notificationsEnabled,
+            statusText: status,
+            nextNotificationText: nil,
+            lastNotification: reminderStore.lastNotification
+        )
+        self.timezones = TimeZone.knownTimeZoneIdentifiers.sorted()
+        self.numberFormatter = NumberFormatter()
+        self.numberFormatter.maximumFractionDigits = 1
+        self.numberFormatter.minimumFractionDigits = 0
+        self.numberFormatter.minimumIntegerDigits = 1
+
+        observeStores()
+        scheduler.ensureRunningIfNeeded()
+    }
+
+    var leadHoursDescription: String {
+        let value = state.leadHours
+        if let formatted = numberFormatter.string(from: NSNumber(value: value)) {
+            return "Lead time: \(formatted) hours"
+        }
+        return String(format: "Lead time: %.1f hours", value)
+    }
+
+    var pollMinutesDescription: String {
+        "Polling interval: \(state.pollMinutes) minutes"
+    }
+
+    func onLeadHoursChanged(_ value: Double) {
+        settingsStore.updateLeadHours(value)
+        if settingsStore.userSettings.notificationsEnabled {
+            scheduler.restart()
+        }
+    }
+
+    func onPollMinutesChanged(_ value: Int) {
+        settingsStore.updatePollMinutes(value)
+        if settingsStore.userSettings.notificationsEnabled {
+            scheduler.restart()
+        }
+    }
+
+    func onTimezoneChanged(_ identifier: String) {
+        settingsStore.updateTimezone(identifier)
+        if settingsStore.userSettings.notificationsEnabled {
+            scheduler.restart()
+        }
+    }
+
+    func onNotificationsToggled(_ enabled: Bool) {
+        if enabled {
+            Task { [weak self] in
+                guard let self = self else { return }
+                let granted = await self.scheduler.requestAuthorizationIfNeeded()
+                if granted {
+                    self.settingsStore.setNotificationsEnabled(true)
+                    self.scheduler.restart()
+                } else {
+                    self.settingsStore.setNotificationsEnabled(false)
+                }
+            }
+        } else {
+            settingsStore.setNotificationsEnabled(false)
+            scheduler.cancel()
+            reminderStore.clearLastNotification()
+        }
+    }
+
+    private func observeStores() {
+        settingsStore.$userSettings
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] settings in
+                guard let self = self else { return }
+                self.state.leadHours = settings.leadHours
+                self.state.pollMinutes = settings.pollMinutes
+                self.state.timezoneId = settings.timezoneId
+                self.state.notificationsEnabled = settings.notificationsEnabled
+                self.state.statusText = MainViewModel.statusText(enabled: settings.notificationsEnabled)
+                self.updateNextNotificationText()
+            }
+            .store(in: &cancellables)
+
+        reminderStore.$lastNotification
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                self?.state.lastNotification = message
+            }
+            .store(in: &cancellables)
+
+        scheduler.$plannedNotification
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] planned in
+                guard let self = self else { return }
+                self.plannedNotification = planned
+                self.updateNextNotificationText()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateNextNotificationText() {
+        guard let planned = plannedNotification else {
+            state.nextNotificationText = nil
+            return
+        }
+        let timezone = TimeZone(identifier: state.timezoneId) ?? .current
+        let formatted = DeadlineFormatter.string(from: planned.notifyAt, timeZone: timezone)
+        state.nextNotificationText = "Reminder for \(planned.gameweek.name) (GW \(planned.gameweek.eventId)) at \(formatted)"
+    }
+
+    private static func statusText(enabled: Bool) -> String {
+        enabled ? "Notifications enabled" : "Notifications disabled"
+    }
+}

--- a/ios-app/FplNotifier/Views/ContentView.swift
+++ b/ios-app/FplNotifier/Views/ContentView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var viewModel: MainViewModel
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Reminders")) {
+                    Toggle("Enable reminders", isOn: Binding(
+                        get: { viewModel.state.notificationsEnabled },
+                        set: { viewModel.onNotificationsToggled($0) }
+                    ))
+                    Stepper(value: Binding(
+                        get: { viewModel.state.leadHours },
+                        set: { viewModel.onLeadHoursChanged($0) }
+                    ), in: 0.5...48, step: 0.5) {
+                        Text(viewModel.leadHoursDescription)
+                    }
+                    Stepper(value: Binding(
+                        get: { viewModel.state.pollMinutes },
+                        set: { viewModel.onPollMinutesChanged($0) }
+                    ), in: 5...1440, step: 5) {
+                        Text(viewModel.pollMinutesDescription)
+                    }
+                }
+
+                Section(header: Text("Timezone")) {
+                    Picker("Timezone", selection: Binding(
+                        get: { viewModel.state.timezoneId },
+                        set: { viewModel.onTimezoneChanged($0) }
+                    )) {
+                        ForEach(viewModel.timezones, id: \.self) { zone in
+                            Text(zone).tag(zone)
+                        }
+                    }
+                }
+
+                Section(header: Text("Status")) {
+                    Text(viewModel.state.statusText)
+                    if let next = viewModel.state.nextNotificationText {
+                        Text(next)
+                    }
+                    if let last = viewModel.state.lastNotification {
+                        Text(last)
+                    }
+                }
+            }
+            .navigationTitle("FPL Notifier")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        let settings = SettingsStore()
+        let reminders = ReminderStore()
+        let scheduler = DeadlineScheduler(settingsStore: settings, reminderStore: reminders)
+        let viewModel = MainViewModel(settingsStore: settings, reminderStore: reminders, scheduler: scheduler)
+        ContentView(viewModel: viewModel)
+    }
+}

--- a/ios-app/FplNotifier/Views/FplNotifierApp.swift
+++ b/ios-app/FplNotifier/Views/FplNotifierApp.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+@main
+struct FplNotifierApp: App {
+    @StateObject private var dependencies = AppDependencies()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(viewModel: dependencies.viewModel)
+                .onAppear {
+                    dependencies.scheduler.ensureRunningIfNeeded()
+                }
+        }
+    }
+}
+
+private final class AppDependencies: ObservableObject {
+    let settingsStore: SettingsStore
+    let reminderStore: ReminderStore
+    let scheduler: DeadlineScheduler
+    let viewModel: MainViewModel
+
+    init() {
+        let settings = SettingsStore()
+        let reminders = ReminderStore()
+        let scheduler = DeadlineScheduler(settingsStore: settings, reminderStore: reminders)
+        let viewModel = MainViewModel(settingsStore: settings, reminderStore: reminders, scheduler: scheduler)
+        self.settingsStore = settings
+        self.reminderStore = reminders
+        self.scheduler = scheduler
+        self.viewModel = viewModel
+    }
+}

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,0 +1,49 @@
+# FplNotifier for iOS
+
+The iOS client mirrors the Android Fantasy Premier League notifier experience. It offers a SwiftUI configuration screen where you can:
+
+- Enable or disable reminder notifications.
+- Choose how many hours before kickoff the reminder should fire.
+- Pick how often the background poll should check for new deadlines.
+- Select the timezone used when displaying deadlines and notifications.
+
+Under the hood the app downloads `https://fantasy.premierleague.com/api/bootstrap-static/`, parses the upcoming gameweek deadlines, and schedules local notifications that match the Android copy.
+
+## Project layout
+
+```
+ios-app/
+  FplNotifier.xcodeproj      # Xcode project targeting iOS 15+
+  FplNotifier/               # Application sources (SwiftUI UI, data layer, scheduler)
+  Tests/FplNotifierTests/    # XCTest targets and JSON fixtures
+```
+
+User preferences and last-notified gameweeks are persisted with `UserDefaults`, so the SwiftUI UI and background scheduler stay in sync across launches.
+
+## Requirements & setup
+
+1. Open `ios-app/FplNotifier.xcodeproj` in Xcode 15 or newer.
+2. Select the *FplNotifier* scheme and choose an iOS 15+ simulator or a provisioned device.
+3. Build & run the project (`⌘R`).
+
+### Notifications
+
+- The first time you toggle "Enable reminders" the app will prompt for notification permissions via `UNUserNotificationCenter`.
+- Local notifications use the default sound and replicate the Android title/body copy, including the selected lead time and timezone.
+- If permissions are denied the toggle is reset and no background work is scheduled.
+
+### Background refresh
+
+- The scheduler uses an internal `Task` loop to poll the Fantasy Premier League API on the configured interval.
+- For reliable delivery on device you should enable *Background App Refresh* in **Settings → General → Background App Refresh** so the app can wake up when suspended.
+- When notifications are disabled the scheduler cancels outstanding work and clears the "last notification" status, matching the Android behavior.
+
+## Running unit tests
+
+The project includes XCTest coverage for the JSON parsing logic. From the repository root you can run:
+
+```bash
+xcodebuild test -project ios-app/FplNotifier.xcodeproj -scheme FplNotifier -destination 'platform=iOS Simulator,name=iPhone 14'
+```
+
+This exercises the parsing flow with bundled fixtures under `ios-app/Tests/FplNotifierTests/Fixtures`.

--- a/ios-app/Tests/FplNotifierTests/Fixtures/bootstrap.json
+++ b/ios-app/Tests/FplNotifierTests/Fixtures/bootstrap.json
@@ -1,0 +1,29 @@
+{
+  "events": [
+    {
+      "id": 1,
+      "name": "Gameweek 1",
+      "deadline_time": "2024-08-10T10:30:00Z"
+    },
+    {
+      "id": 2,
+      "name": "Gameweek 2",
+      "deadline_time": "2024-08-17T10:30:00Z"
+    },
+    {
+      "id": 3,
+      "name": "Gameweek 3",
+      "deadline_time": "2024-08-24T10:30:00+00:00"
+    },
+    {
+      "id": 4,
+      "name": "Invalid past",
+      "deadline_time": "2023-08-10T10:30:00Z"
+    },
+    {
+      "id": -5,
+      "name": "Negative",
+      "deadline_time": "2024-08-10T10:30:00Z"
+    }
+  ]
+}

--- a/ios-app/Tests/FplNotifierTests/GameweekDeadlineTests.swift
+++ b/ios-app/Tests/FplNotifierTests/GameweekDeadlineTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import FplNotifier
+
+final class GameweekDeadlineTests: XCTestCase {
+    private let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    func testParsesUpcomingDeadlines() async throws {
+        let data = try loadFixture()
+        let repository = FplApiRepository(fetcher: { _ in data })
+        let now = isoFormatter.date(from: "2024-08-01T00:00:00Z")!
+        let deadlines = try await repository.getUpcomingDeadlines(now: now)
+        XCTAssertEqual(deadlines.count, 3)
+        XCTAssertEqual(deadlines.map(\.eventId), [1, 2, 3])
+        XCTAssertEqual(deadlines.first?.name, "Gameweek 1")
+    }
+
+    func testSkipsPastDeadlines() async throws {
+        let data = try loadFixture()
+        let repository = FplApiRepository(fetcher: { _ in data })
+        let now = isoFormatter.date(from: "2024-08-18T00:00:00Z")!
+        let deadlines = try await repository.getUpcomingDeadlines(now: now)
+        XCTAssertEqual(deadlines.map(\.eventId), [3])
+    }
+
+    private func loadFixture() throws -> Data {
+        let bundle = Bundle(for: type(of: self))
+        guard let url = bundle.url(forResource: "bootstrap", withExtension: "json") else {
+            throw XCTSkip("Fixture missing")
+        }
+        return try Data(contentsOf: url)
+    }
+}

--- a/ios-app/Tests/FplNotifierTests/Info.plist
+++ b/ios-app/Tests/FplNotifierTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDevelopmentRegion</key>
+<string>$(DEVELOPMENT_LANGUAGE)</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleName</key>
+<string>$(PRODUCT_NAME)</string>
+<key>CFBundlePackageType</key>
+<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+<key>CFBundleShortVersionString</key>
+<string>1.0</string>
+<key>CFBundleVersion</key>
+<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a SwiftUI-based iOS target that mirrors the Android reminder controls
- port the Fantasy Premier League API repository, settings persistence, and scheduler logic to Swift
- cover deadline parsing with XCTest fixtures and document build, notification, and background refresh setup

## Testing
- not run (xcodebuild unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d06787cac8833292e6efe499475b2d