### PR TITLE
Add draft deadline reminders

### DIFF
--- a/android-app/app/src/main/java/com/example/fplnotifier/NotificationHelper.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/NotificationHelper.kt
@@ -16,20 +16,34 @@ import kotlin.math.abs
 
 object NotificationHelper {
     const val CHANNEL_ID = "fpl_deadlines"
+    const val DRAFT_CHANNEL_ID = "fpl_draft_deadlines"
+
+    private const val STANDARD_NOTIFICATION_OFFSET = 1
+    private const val DRAFT_NOTIFICATION_OFFSET = 2
 
     private val leadFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z")
 
     fun ensureChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            val channel = NotificationChannel(
+            val standardChannel = NotificationChannel(
                 CHANNEL_ID,
                 context.getString(R.string.app_name),
                 NotificationManager.IMPORTANCE_HIGH
-            )
-            channel.description = "Upcoming Fantasy Premier League deadlines"
-            channel.enableVibration(true)
-            manager.createNotificationChannel(channel)
+            ).apply {
+                description = "Upcoming Fantasy Premier League deadlines"
+                enableVibration(true)
+            }
+            val draftChannel = NotificationChannel(
+                DRAFT_CHANNEL_ID,
+                context.getString(R.string.app_name) + " Draft",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "FPL draft deadline reminders"
+                enableVibration(true)
+            }
+            manager.createNotificationChannel(standardChannel)
+            manager.createNotificationChannel(draftChannel)
         }
     }
 
@@ -45,28 +59,37 @@ object NotificationHelper {
         val title = "FPL deadline in $formattedLead"
         val message = "${gameweek.name} (GW ${gameweek.eventId}) deadline at $deadlineLocal"
 
-        val intent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        val notification = buildNotification(context, CHANNEL_ID, title, message)
+
+        NotificationManagerCompat.from(context)
+            .notify(notificationId(gameweek.eventId, STANDARD_NOTIFICATION_OFFSET), notification)
+    }
+
+    fun sendDraftNotification(
+        context: Context,
+        gameweek: GameweekDeadline,
+        timezone: ZoneId,
+    ) {
+        ensureChannel(context)
+        val draftLock = gameweek.deadline.minus(Duration.ofHours(24))
+        val deadlineLocal = gameweek.deadlineIn(timezone).format(leadFormatter)
+        val draftLockLocal = draftLock.atZone(timezone).format(leadFormatter)
+        val title = "Draft deadline approaching"
+        val message = buildString {
+            append("Draft transactions lock 24 hours before the FPL deadline. ")
+            append(gameweek.name)
+            append(" (GW ")
+            append(gameweek.eventId)
+            append(") draft window closes at ")
+            append(draftLockLocal)
+            append(", final deadline at ")
+            append(deadlineLocal)
         }
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
-            .setContentTitle(title)
-            .setContentText(message)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
-            .setContentIntent(pendingIntent)
-            .setAutoCancel(true)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setDefaults(Notification.DEFAULT_ALL)
-            .build()
+        val notification = buildNotification(context, DRAFT_CHANNEL_ID, title, message)
 
-        NotificationManagerCompat.from(context).notify(gameweek.eventId, notification)
+        NotificationManagerCompat.from(context)
+            .notify(notificationId(gameweek.eventId, DRAFT_NOTIFICATION_OFFSET), notification)
     }
 
     private fun formatLead(delta: Duration): String {
@@ -89,5 +112,36 @@ object NotificationHelper {
             parts += if (seconds == 1L) "1 second" else "$seconds seconds"
         }
         return parts.joinToString(" and ")
+    }
+
+    private fun buildNotification(
+        context: Context,
+        channelId: String,
+        title: String,
+        message: String,
+    ): Notification {
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(Notification.DEFAULT_ALL)
+            .build()
+    }
+
+    private fun notificationId(eventId: Int, offset: Int): Int {
+        return eventId * 10 + offset
     }
 }

--- a/android-app/app/src/main/java/com/example/fplnotifier/SettingsRepository.kt
+++ b/android-app/app/src/main/java/com/example/fplnotifier/SettingsRepository.kt
@@ -19,12 +19,14 @@ private val KEY_LEAD_HOURS = doublePreferencesKey("lead_hours")
 private val KEY_POLL_MINUTES = longPreferencesKey("poll_minutes")
 private val KEY_TIMEZONE = stringPreferencesKey("timezone")
 private val KEY_NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
+private val KEY_DRAFT_NOTIFICATIONS_ENABLED = booleanPreferencesKey("draft_notifications_enabled")
 
 data class UserSettings(
     val leadHours: Double,
     val pollMinutes: Long,
     val timezoneId: String,
     val notificationsEnabled: Boolean,
+    val draftNotificationsEnabled: Boolean,
 )
 
 class SettingsRepository(private val context: Context) {
@@ -37,6 +39,7 @@ class SettingsRepository(private val context: Context) {
             pollMinutes = prefs[KEY_POLL_MINUTES] ?: 360,
             timezoneId = prefs[KEY_TIMEZONE] ?: defaultTz,
             notificationsEnabled = prefs[KEY_NOTIFICATIONS_ENABLED] ?: false,
+            draftNotificationsEnabled = prefs[KEY_DRAFT_NOTIFICATIONS_ENABLED] ?: false,
         )
     }
 
@@ -61,6 +64,12 @@ class SettingsRepository(private val context: Context) {
     suspend fun setNotificationsEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[KEY_NOTIFICATIONS_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setDraftNotificationsEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_DRAFT_NOTIFICATIONS_ENABLED] = enabled
         }
     }
 }

--- a/android-app/app/src/main/res/layout/activity_main.xml
+++ b/android-app/app/src/main/res/layout/activity_main.xml
@@ -61,6 +61,13 @@
             android:layout_marginBottom="24dp"
             android:text="@string/enable_reminders" />
 
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/toggleDraftReminders"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:text="@string/enable_draft_reminders" />
+
         <TextView
             android:id="@+id/textStatus"
             android:layout_width="match_parent"

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -4,9 +4,14 @@
     <string name="poll_minutes_label">Polling interval (minutes)</string>
     <string name="timezone_label">Timezone</string>
     <string name="enable_reminders">Enable reminders</string>
+    <string name="enable_draft_reminders">Enable draft deadline reminders</string>
     <string name="status_heading">Status</string>
     <string name="last_notification_none">No reminders sent yet.</string>
     <string name="save_changes">Settings are saved automatically.</string>
     <string name="notifications_disabled">Background reminders are disabled.</string>
-    <string name="notifications_enabled">Background reminders are enabled.</string>
+    <string name="notifications_enabled_types">Background reminders enabled: %1$s.</string>
+    <string name="status_type_standard">standard</string>
+    <string name="status_type_draft">draft</string>
+    <string name="last_notification_standard">Sent standard reminder for %1$s (GW %2$d) at %3$s.</string>
+    <string name="last_notification_draft">Sent draft reminder for %1$s (GW %2$d); draft window closed at %3$s (final deadline %4$s).</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated notification channel and helper for draft deadline alerts
- tag stored reminders with their type and expose draft notification settings
- update the worker, repositories, and UI to schedule and display draft reminders

## Testing
- `./gradlew app:lint` *(fails: Android SDK not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc4acd1308332b1d5cee4d1f5a569