### PR TITLE
Add draft reminder support to iOS scheduler

### DIFF
--- a/ios-app/FplNotifier/Data/SettingsStore.swift
+++ b/ios-app/FplNotifier/Data/SettingsStore.swift
@@ -7,6 +7,7 @@ final class SettingsStore: ObservableObject {
         var pollMinutes: Int
         var timezoneId: String
         var notificationsEnabled: Bool
+        var draftNotificationsEnabled: Bool = false
     }
 
     @Published private(set) var userSettings: UserSettings
@@ -26,7 +27,8 @@ final class SettingsStore: ObservableObject {
                 leadHours: 2.0,
                 pollMinutes: 360,
                 timezoneId: TimeZone.current.identifier,
-                notificationsEnabled: false
+                notificationsEnabled: false,
+                draftNotificationsEnabled: false
             )
             self.userSettings = fallback
         }
@@ -55,6 +57,12 @@ final class SettingsStore: ObservableObject {
     func setNotificationsEnabled(_ enabled: Bool) {
         guard userSettings.notificationsEnabled != enabled else { return }
         userSettings.notificationsEnabled = enabled
+        persist()
+    }
+
+    func setDraftNotificationsEnabled(_ enabled: Bool) {
+        guard userSettings.draftNotificationsEnabled != enabled else { return }
+        userSettings.draftNotificationsEnabled = enabled
         persist()
     }
 

--- a/ios-app/FplNotifier/Scheduling/NotificationHelper.swift
+++ b/ios-app/FplNotifier/Scheduling/NotificationHelper.swift
@@ -35,17 +35,28 @@ enum NotificationHelper {
     static func sendNotification(
         for gameweek: GameweekDeadline,
         leadTime: TimeInterval,
+        type: ReminderStore.SentReminder.ReminderType,
         timezone: TimeZone,
         center: UNUserNotificationCenter = .current()
     ) async {
         let content = UNMutableNotificationContent()
-        let leadDescription = formatLeadTime(leadTime)
-        content.title = "FPL deadline in \(leadDescription)"
-        content.body = "\(gameweek.name) (GW \(gameweek.eventId)) deadline at \(DeadlineFormatter.format(gameweek, in: timezone))"
+        let identifier: String
+        switch type {
+        case .standard:
+            let leadDescription = formatLeadTime(leadTime)
+            content.title = "FPL deadline in \(leadDescription)"
+            content.body = "\(gameweek.name) (GW \(gameweek.eventId)) deadline at \(DeadlineFormatter.format(gameweek, in: timezone))"
+            identifier = "fpl_deadline_\(gameweek.eventId)"
+        case .draft:
+            let leadDescription = formatLeadTime(leadTime)
+            content.title = "Draft reminder: FPL deadline in \(leadDescription)"
+            content.body = "Set your draft squad before \(gameweek.name) (GW \(gameweek.eventId)) deadline at \(DeadlineFormatter.format(gameweek, in: timezone))"
+            identifier = "fpl_deadline_draft_\(gameweek.eventId)"
+        }
         content.sound = .default
 
         let request = UNNotificationRequest(
-            identifier: "fpl_deadline_\(gameweek.eventId)",
+            identifier: identifier,
             content: content,
             trigger: nil
         )

--- a/ios-app/FplNotifier/Views/ContentView.swift
+++ b/ios-app/FplNotifier/Views/ContentView.swift
@@ -11,6 +11,10 @@ struct ContentView: View {
                         get: { viewModel.state.notificationsEnabled },
                         set: { viewModel.onNotificationsToggled($0) }
                     ))
+                    Toggle("Enable draft reminder", isOn: Binding(
+                        get: { viewModel.state.draftNotificationsEnabled },
+                        set: { viewModel.onDraftNotificationsToggled($0) }
+                    ))
                     Stepper(value: Binding(
                         get: { viewModel.state.leadHours },
                         set: { viewModel.onLeadHoursChanged($0) }


### PR DESCRIPTION
## Summary
- persist a draft reminder preference and expose it through the main view model and UI
- track reminder types when recording and scheduling notifications so draft and standard alerts can coexist
- schedule both standard and 24-hour draft reminders and send draft-specific notification content

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e34f74a2a4833287ad35685348c2bc